### PR TITLE
Update HACS metadata for Satel integration

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,8 @@
 {
-  "name": "ThesslaGreen Modbus",
+  "name": "Satel",
   "content_in_root": false,
   "render_readme": true,
-  "domains": ["climate", "sensor", "binary_sensor", "select", "number", "switch"],
-  "iot_class": "Local Polling",
-  "version": "1.0.0"
+  "domains": ["binary_sensor", "sensor", "switch"],
+  "iot_class": "local_polling",
+  "version": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- update HACS configuration for Satel integration

## Testing
- `python -m json.tool hacs.json`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8cc9fc1c832684976f6449fabee6