### PR TITLE
feat: generate Satel entities dynamically

### DIFF
--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
 
 from . import SatelHub
 from .const import DOMAIN
@@ -14,20 +13,31 @@ from .const import DOMAIN
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
+    """Set up Satel zone sensors based on config entry."""
     hub: SatelHub = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([SatelStatusSensor(hub)], True)
+    status = await hub.get_status()
+    entities = [SatelZoneSensor(hub, zone) for zone in status["zones"]]
+    async_add_entities(entities, True)
 
 
-class SatelStatusSensor(SensorEntity):
-    """Representation of Satel status sensor."""
+class SatelZoneSensor(SensorEntity):
+    """Representation of a Satel zone sensor."""
 
-    _attr_name = "Satel Status"
-
-    def __init__(self, hub: SatelHub) -> None:
+    def __init__(self, hub: SatelHub, zone_id: str) -> None:
         self._hub = hub
-        self._attr_native_unit_of_measurement = None
-        self._attr_unique_id = "satel_status"
+        self._zone_id = zone_id
+        self._attr_unique_id = f"satel_zone_sensor_{zone_id}"
+        self._attr_name = f"Satel Zone {zone_id}"
 
     async def async_update(self) -> None:
         data = await self._hub.get_status()
-        self._attr_native_value = data.get("raw")
+        self._attr_native_value = "on" if data["zones"].get(self._zone_id) else "off"
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, "satel")},
+            "name": "Satel Alarm",
+            "manufacturer": "Satel",
+        }
+


### PR DESCRIPTION
## Summary
- dynamically create Satel zones and outputs
- report device info for entities
- read output state via hub

## Testing
- `python -m py_compile custom_components/satel/__init__.py custom_components/satel/binary_sensor.py custom_components/satel/sensor.py custom_components/satel/switch.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f8cced7308326a441be1d79511c33