### PR TITLE
Add authentication to Satel integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Satel Alarm Integration
+
+This repository contains a custom Home Assistant integration for Satel alarm systems.
+
+## Configuration
+
+The integration can be configured via the Home Assistant UI. The following options are available:
+
+- `host` (required): Address of the Satel central unit.
+- `port` (required): TCP port used to communicate with the central.
+- `user_code` (optional): Code used for authenticating the connection.
+- `encryption_key` (optional): Encryption key for secure communication.
+
+Provide the appropriate credentials when adding the integration to enable authenticated access to the alarm system.

--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -11,7 +11,13 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN, DEFAULT_HOST, DEFAULT_PORT
+from .const import (
+    DOMAIN,
+    DEFAULT_HOST,
+    DEFAULT_PORT,
+    CONF_ENCRYPTION_KEY,
+    CONF_USER_CODE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -21,9 +27,17 @@ PLATFORMS: list[str] = ["sensor", "binary_sensor", "switch"]
 class SatelHub:
     """Simple Satel client communicating over TCP."""
 
-    def __init__(self, host: str, port: int) -> None:
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        user_code: str | None = None,
+        encryption_key: str | None = None,
+    ) -> None:
         self._host = host
         self._port = port
+        self._user_code = user_code
+        self._encryption_key = encryption_key
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
 
@@ -33,6 +47,19 @@ class SatelHub:
         self._reader, self._writer = await asyncio.open_connection(
             self._host, self._port
         )
+        if self._user_code or self._encryption_key:
+            auth_parts: list[str] = []
+            if self._user_code:
+                auth_parts.append(self._user_code)
+            if self._encryption_key:
+                auth_parts.append(self._encryption_key)
+            auth_cmd = "AUTH " + " ".join(auth_parts)
+            _LOGGER.debug("Authenticating with Satel central")
+            self._writer.write((auth_cmd + "\n").encode())
+            await self._writer.drain()
+            response = await self._reader.readline()
+            if response.decode().strip().upper() != "OK":
+                raise ConnectionError("Authentication failed")
 
     async def send_command(self, command: str) -> str:
         """Send a command to the Satel central and return response."""
@@ -65,8 +92,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Satel from a config entry."""
     host = entry.data.get(CONF_HOST, DEFAULT_HOST)
     port = entry.data.get(CONF_PORT, DEFAULT_PORT)
+    user_code = entry.data.get(CONF_USER_CODE)
+    encryption_key = entry.data.get(CONF_ENCRYPTION_KEY)
 
-    hub = SatelHub(host, port)
+    hub = SatelHub(host, port, user_code, encryption_key)
     await hub.connect()
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = hub

--- a/custom_components/satel/config_flow.py
+++ b/custom_components/satel/config_flow.py
@@ -7,7 +7,13 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import DOMAIN, DEFAULT_PORT, DEFAULT_HOST
+from .const import (
+    DOMAIN,
+    DEFAULT_PORT,
+    DEFAULT_HOST,
+    CONF_ENCRYPTION_KEY,
+    CONF_USER_CODE,
+)
 
 
 class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -26,6 +32,8 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
                 vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
+                vol.Optional(CONF_USER_CODE): str,
+                vol.Optional(CONF_ENCRYPTION_KEY): str,
             }
         )
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)

--- a/custom_components/satel/const.py
+++ b/custom_components/satel/const.py
@@ -1,3 +1,5 @@
 DOMAIN = "satel"
 DEFAULT_PORT = 7094
 DEFAULT_HOST = "127.0.0.1"
+CONF_USER_CODE = "user_code"
+CONF_ENCRYPTION_KEY = "encryption_key"

--- a/custom_components/satel/manifest.json
+++ b/custom_components/satel/manifest.json
@@ -6,5 +6,6 @@
   "requirements": [],
   "codeowners": ["@yourname"],
   "config_flow": true,
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "authentication": ["user_code", "encryption_key"]
 }


### PR DESCRIPTION
## Summary
- support user code and encryption key in config flow
- authenticate connection using provided credentials
- document authentication options in manifest and README

## Testing
- `pre-commit run --files custom_components/satel/__init__.py custom_components/satel/config_flow.py custom_components/satel/const.py custom_components/satel/manifest.json README.md` *(fails: .pre-commit-config.yaml is not a file)*
- `python -m py_compile custom_components/satel/__init__.py custom_components/satel/config_flow.py custom_components/satel/const.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8cd37b0c8326841a2c489f562b6d