### PR TITLE
Add Satel tests and config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Satel Alarm Home Assistant Integration
+
+This custom component provides a simple integration with Satel alarm systems.
+
+## Configuration
+
+### UI setup
+
+1. In Home Assistant navigate to **Settings → Devices & Services**.
+2. Click **Add Integration** and search for **Satel**.
+3. Enter the host and port of your Satel interface and finish the flow.
+
+### YAML configuration
+
+The integration can also be configured in `configuration.yaml`:
+
+```yaml
+satel:
+  host: 192.168.1.2
+  port: 7094
+```
+
+After adding the configuration, restart Home Assistant.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest_plugins = ("pytest_homeassistant_custom_component",)
+
+# Ensure custom_components is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,58 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.satel import SatelHub
+
+
+class DummyWriter:
+    """Helper writer object for tests."""
+
+    def __init__(self):
+        self.data = b""
+
+    def write(self, data: bytes) -> None:
+        self.data += data
+
+    async def drain(self) -> None:
+        pass
+
+    def close(self) -> None:  # pragma: no cover - cleanup
+        pass
+
+    async def wait_closed(self) -> None:  # pragma: no cover - cleanup
+        pass
+
+
+@pytest.mark.asyncio
+async def test_connect_and_send_command(monkeypatch):
+    """Test that commands are sent and responses are received."""
+    reader = asyncio.StreamReader()
+    writer = DummyWriter()
+
+    async def mock_open_connection(host, port):
+        return reader, writer
+
+    monkeypatch.setattr(asyncio, "open_connection", mock_open_connection)
+
+    hub = SatelHub("test", 1234)
+    await hub.connect()
+
+    reader.feed_data(b"PONG\n")
+    result = await hub.send_command("PING")
+
+    assert result == "PONG"
+    assert writer.data == b"PING\n"
+
+
+@pytest.mark.asyncio
+async def test_get_status(monkeypatch):
+    """Verify get_status wraps send_command output."""
+    hub = SatelHub("host", 1234)
+    monkeypatch.setattr(hub, "send_command", AsyncMock(return_value="ALARM"))
+
+    status = await hub.get_status()
+
+    hub.send_command.assert_awaited_once_with("STATUS")
+    assert status == {"raw": "ALARM"}

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,59 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.const import CONF_HOST, CONF_PORT
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.satel.const import DOMAIN, DEFAULT_HOST, DEFAULT_PORT
+
+
+@pytest.mark.asyncio
+async def test_setup_creates_entities(hass, enable_custom_integrations):
+    """Test setting up the Satel integration creates entities."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: DEFAULT_HOST, CONF_PORT: DEFAULT_PORT})
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.satel.SatelHub.connect", AsyncMock()), \
+        patch("custom_components.satel.SatelHub.get_status", AsyncMock(return_value={"raw": "ALARM"})):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.satel_alarm")
+    assert state is not None
+    assert state.state == "on"
+
+    state = hass.states.get("sensor.satel_status")
+    assert state is not None
+    assert state.state == "ALARM"
+
+
+@pytest.mark.asyncio
+async def test_switch_services(hass, enable_custom_integrations):
+    """Ensure switch entity calls hub on service invocations."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_HOST: DEFAULT_HOST, CONF_PORT: DEFAULT_PORT})
+    entry.add_to_hass(hass)
+
+    with patch("custom_components.satel.SatelHub.connect", AsyncMock()), \
+        patch(
+            "custom_components.satel.SatelHub.get_status",
+            AsyncMock(return_value={"raw": "READY"}),
+        ), \
+        patch(
+            "custom_components.satel.SatelHub.send_command", AsyncMock()
+        ) as mock_send:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        entity_id = "switch.satel_output"
+
+        await hass.services.async_call(
+            "switch", "turn_on", {"entity_id": entity_id}, blocking=True
+        )
+        assert mock_send.await_args_list[0].args[0] == "OUTPUT ON"
+        assert hass.states.get(entity_id).state == "on"
+
+        await hass.services.async_call(
+            "switch", "turn_off", {"entity_id": entity_id}, blocking=True
+        )
+        assert mock_send.await_args_list[1].args[0] == "OUTPUT OFF"
+        assert hass.states.get(entity_id).state == "off"


### PR DESCRIPTION
## Summary
- add README with UI/YAML configuration example
- add pytest-based unit tests for SatelHub and entity setup
- configure pytest for asyncio support

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f8cd129e4832699e05a42cc044bfd