### PR TITLE
Add device discovery and dynamic entities

### DIFF
--- a/custom_components/satel/config_flow.py
+++ b/custom_components/satel/config_flow.py
@@ -6,7 +6,9 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import config_validation as cv
 
+from . import SatelHub
 from .const import DOMAIN, DEFAULT_PORT, DEFAULT_HOST
 
 
@@ -18,9 +20,12 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None) -> FlowResult:
         errors = {}
         if user_input is not None:
-            return self.async_create_entry(
-                title=f"Satel {user_input[CONF_HOST]}", data=user_input
-            )
+            self._host = user_input[CONF_HOST]
+            self._port = user_input[CONF_PORT]
+            hub = SatelHub(self._host, self._port)
+            await hub.connect()
+            self._devices = await hub.discover_devices()
+            return await self.async_step_select()
 
         data_schema = vol.Schema(
             {
@@ -29,3 +34,25 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    async def async_step_select(self, user_input=None) -> FlowResult:
+        if user_input is not None:
+            return self.async_create_entry(
+                title=f"Satel {self._host}",
+                data={
+                    CONF_HOST: self._host,
+                    CONF_PORT: self._port,
+                    "zones": user_input.get("zones", []),
+                    "outputs": user_input.get("outputs", []),
+                },
+            )
+
+        zone_options = {z["id"]: z["name"] for z in self._devices.get("zones", [])}
+        output_options = {o["id"]: o["name"] for o in self._devices.get("outputs", [])}
+        data_schema = vol.Schema(
+            {
+                vol.Optional("zones", default=list(zone_options)): cv.multi_select(zone_options),
+                vol.Optional("outputs", default=list(output_options)): cv.multi_select(output_options),
+            }
+        )
+        return self.async_show_form(step_id="select", data_schema=data_schema)

--- a/custom_components/satel/manifest.json
+++ b/custom_components/satel/manifest.json
@@ -6,5 +6,6 @@
   "requirements": [],
   "codeowners": ["@yourname"],
   "config_flow": true,
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "description": "Connects to a Satel alarm panel and automatically discovers zones and outputs during setup. Discovery uses a basic LIST command and may not detect all device types."
 }


### PR DESCRIPTION
## Summary
- add hub discovery for zones and outputs
- create entities dynamically from discovered devices
- allow selecting devices during config flow
- document autoscan capability

## Testing
- `pytest -q`
- `python -m py_compile custom_components/satel/*.py`


------
https://chatgpt.com/codex/tasks/task_e_688f8ded0fd483268ec199b9c9a0ba6d