### PR TITLE
Add config flow translations

### DIFF
--- a/custom_components/satel/strings.json
+++ b/custom_components/satel/strings.json
@@ -1,0 +1,27 @@
+{
+  "title": "Satel Alarm",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Satel",
+        "description": "Set up connection to your Satel alarm panel.",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      },
+      "select": {
+        "title": "Select devices",
+        "description": "Choose zones and outputs to add.",
+        "data": {
+          "zones": "Zones",
+          "outputs": "Outputs"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "unknown": "Unexpected error"
+    }
+  }
+}

--- a/custom_components/satel/translations/en.json
+++ b/custom_components/satel/translations/en.json
@@ -1,0 +1,27 @@
+{
+  "title": "Satel Alarm",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to Satel",
+        "description": "Set up connection to your Satel alarm panel.",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      },
+      "select": {
+        "title": "Select devices",
+        "description": "Choose zones and outputs to add.",
+        "data": {
+          "zones": "Zones",
+          "outputs": "Outputs"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect",
+      "unknown": "Unexpected error"
+    }
+  }
+}

--- a/custom_components/satel/translations/pl.json
+++ b/custom_components/satel/translations/pl.json
@@ -1,0 +1,27 @@
+{
+  "title": "Alarm Satel",
+  "config": {
+    "step": {
+      "user": {
+        "title": "Połącz z Satel",
+        "description": "Skonfiguruj połączenie z centralą Satel.",
+        "data": {
+          "host": "Host",
+          "port": "Port"
+        }
+      },
+      "select": {
+        "title": "Wybierz urządzenia",
+        "description": "Wybierz strefy i wyjścia do dodania.",
+        "data": {
+          "zones": "Strefy",
+          "outputs": "Wyjścia"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Nie udało się połączyć",
+      "unknown": "Nieoczekiwany błąd"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add English translations and base strings for Satel config flow
- provide Polish translation file

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f91b8bb40832699e5415691de1e57