### PR TITLE
Add device info for Satel entities

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -27,6 +27,11 @@ class SatelHub:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
 
+    @property
+    def host(self) -> str:
+        """Return the host address of the Satel hub."""
+        return self._host
+
     async def connect(self) -> None:
         """Connect to the Satel central."""
         _LOGGER.debug("Connecting to %s:%s", self._host, self._port)

--- a/custom_components/satel/binary_sensor.py
+++ b/custom_components/satel/binary_sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import SatelHub
 from .const import DOMAIN
@@ -31,6 +32,15 @@ class SatelZoneBinarySensor(BinarySensorEntity):
         self._zone_id = zone_id
         self._attr_name = name
         self._attr_unique_id = f"satel_zone_{zone_id}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._hub.host)},
+            manufacturer="Satel",
+            name="Satel Alarm",
+        )
 
     async def async_update(self) -> None:
         status = await self._hub.send_command(f"ZONE {self._zone_id}")

--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import SatelHub
 from .const import DOMAIN
@@ -31,6 +32,15 @@ class SatelZoneSensor(SensorEntity):
         self._zone_id = zone_id
         self._attr_name = f"{name} status"
         self._attr_unique_id = f"satel_zone_status_{zone_id}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._hub.host)},
+            manufacturer="Satel",
+            name="Satel Alarm",
+        )
 
     async def async_update(self) -> None:
         self._attr_native_value = await self._hub.send_command(

--- a/custom_components/satel/switch.py
+++ b/custom_components/satel/switch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import SatelHub
 from .const import DOMAIN
@@ -32,6 +33,15 @@ class SatelOutputSwitch(SwitchEntity):
         self._attr_name = name
         self._attr_is_on = False
         self._attr_unique_id = f"satel_output_{output_id}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._hub.host)},
+            manufacturer="Satel",
+            name="Satel Alarm",
+        )
 
     async def async_turn_on(self, **kwargs) -> None:
         await self._hub.send_command(f"OUTPUT {self._output_id} ON")


### PR DESCRIPTION
## Summary
- expose Satel hub host for device info
- add device info to Satel zone and output entities

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f91b7e3648326a57062586efb2daf