### PR TITLE
Add Satel alarm control panel platform

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -15,7 +15,12 @@ from .const import DOMAIN, DEFAULT_HOST, DEFAULT_PORT
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["sensor", "binary_sensor", "switch"]
+PLATFORMS: list[str] = [
+    "sensor",
+    "binary_sensor",
+    "switch",
+    "alarm_control_panel",
+]
 
 
 class SatelHub:
@@ -78,6 +83,14 @@ class SatelHub:
                 "outputs": [{"id": "1", "name": "Output 1"}],
             }
         return metadata
+
+    async def arm(self) -> None:
+        """Arm the alarm."""
+        await self.send_command("ARM")
+
+    async def disarm(self) -> None:
+        """Disarm the alarm."""
+        await self.send_command("DISARM")
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/satel/alarm_control_panel.py
+++ b/custom_components/satel/alarm_control_panel.py
@@ -1,0 +1,51 @@
+"""Satel alarm control panel."""
+
+from __future__ import annotations
+
+from homeassistant.components.alarm_control_panel import (
+    AlarmControlPanelEntity,
+    AlarmControlPanelEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ALARM_ARMED_AWAY, STATE_ALARM_DISARMED
+from homeassistant.core import HomeAssistant
+
+from . import SatelHub
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities
+) -> None:
+    """Set up Satel alarm control panel from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    hub: SatelHub = data["hub"]
+    async_add_entities([SatelAlarmPanel(hub)], True)
+
+
+class SatelAlarmPanel(AlarmControlPanelEntity):
+    """Representation of the Satel alarm panel."""
+
+    _attr_name = "Satel Alarm"
+    _attr_unique_id = "satel_alarm"
+    _attr_supported_features = AlarmControlPanelEntityFeature.ARM_AWAY
+
+    def __init__(self, hub: SatelHub) -> None:
+        self._hub = hub
+        self._attr_state = STATE_ALARM_DISARMED
+
+    async def async_alarm_arm_away(self, code: str | None = None) -> None:
+        await self._hub.arm()
+        self._attr_state = STATE_ALARM_ARMED_AWAY
+
+    async def async_alarm_disarm(self, code: str | None = None) -> None:
+        await self._hub.disarm()
+        self._attr_state = STATE_ALARM_DISARMED
+
+    async def async_update(self) -> None:
+        status = await self._hub.send_command("STATUS")
+        if status.upper() == "ARMED":
+            self._attr_state = STATE_ALARM_ARMED_AWAY
+        else:
+            self._attr_state = STATE_ALARM_DISARMED
+


### PR DESCRIPTION
## Summary
- extend SatelHub with arm and disarm helpers
- add alarm control panel entity using the hub
- register the new platform for automatic setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f92d0dc148326ab29d98ce62f3f43