### PR TITLE
Add tests for Satel integration

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,2 @@
+"""Test suite for Satel integration."""
+pytest_plugins = ["pytest_homeassistant_custom_component"]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,47 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant import data_entry_flow
+from homeassistant.const import CONF_HOST, CONF_PORT
+
+from custom_components.satel.const import DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_config_flow_full(hass):
+    devices = {
+        "zones": [{"id": "1", "name": "Zone"}],
+        "outputs": [{"id": "2", "name": "Out"}],
+    }
+    with patch("custom_components.satel.config_flow.SatelHub") as hub_cls:
+        hub = hub_cls.return_value
+        hub.connect = AsyncMock()
+        hub.discover_devices = AsyncMock(return_value=devices)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", CONF_PORT: 1234}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "select"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"zones": ["1"], "outputs": ["2"]}
+        )
+
+        assert result["type"] == data_entry_flow.FlowResultType.CREATE_ENTRY
+        assert result["title"] == "Satel 1.2.3.4"
+        assert result["data"] == {
+            CONF_HOST: "1.2.3.4",
+            CONF_PORT: 1234,
+            "zones": ["1"],
+            "outputs": ["2"],
+        }
+
+        hub.connect.assert_awaited_once()
+        hub.discover_devices.assert_awaited_once()

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,64 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.satel import SatelHub
+
+
+@pytest.mark.asyncio
+async def test_connect(monkeypatch):
+    reader = AsyncMock()
+    writer = AsyncMock()
+    open_mock = AsyncMock(return_value=(reader, writer))
+    monkeypatch.setattr(asyncio, "open_connection", open_mock)
+
+    hub = SatelHub("1.2.3.4", 1234)
+    await hub.connect()
+
+    open_mock.assert_awaited_once_with("1.2.3.4", 1234)
+    assert hub._reader is reader
+    assert hub._writer is writer
+
+
+@pytest.mark.asyncio
+async def test_send_command(monkeypatch):
+    hub = SatelHub("1.2.3.4", 1234)
+    reader = AsyncMock()
+    reader.readline = AsyncMock(return_value=b"OK\n")
+    writer = MagicMock()
+    writer.drain = AsyncMock()
+    writer.write = MagicMock()
+    hub._reader = reader
+    hub._writer = writer
+
+    response = await hub.send_command("TEST")
+
+    writer.write.assert_called_once_with(b"TEST\n")
+    writer.drain.assert_awaited_once()
+    reader.readline.assert_awaited_once()
+    assert response == "OK"
+
+
+@pytest.mark.asyncio
+async def test_send_command_not_connected():
+    hub = SatelHub("1.2.3.4", 1234)
+    with pytest.raises(ConnectionError):
+        await hub.send_command("TEST")
+
+
+@pytest.mark.asyncio
+async def test_discover_devices(monkeypatch):
+    hub = SatelHub("1.2.3.4", 1234)
+    monkeypatch.setattr(
+        hub,
+        "send_command",
+        AsyncMock(return_value="1=Zone1,2=Zone2|1=Out1,3=Out3"),
+    )
+
+    devices = await hub.discover_devices()
+
+    assert devices == {
+        "zones": [{"id": "1", "name": "Zone1"}, {"id": "2", "name": "Zone2"}],
+        "outputs": [{"id": "1", "name": "Out1"}, {"id": "3", "name": "Out3"}],
+    }

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,0 +1,59 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.satel import SatelHub
+from custom_components.satel.const import DOMAIN
+from custom_components.satel import binary_sensor, sensor, switch
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_setup_entry(hass):
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    hub = SatelHub("host", 1234)
+    devices = {"zones": [{"id": "1", "name": "Zone"}], "outputs": []}
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub, "devices": devices}}
+
+    add_entities = MagicMock()
+    await binary_sensor.async_setup_entry(hass, entry, add_entities)
+
+    add_entities.assert_called_once()
+    entities = add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert entities[0].unique_id == "satel_zone_1"
+
+
+@pytest.mark.asyncio
+async def test_sensor_setup_entry(hass):
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    hub = SatelHub("host", 1234)
+    devices = {"zones": [{"id": "1", "name": "Zone"}], "outputs": []}
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub, "devices": devices}}
+
+    add_entities = MagicMock()
+    await sensor.async_setup_entry(hass, entry, add_entities)
+
+    add_entities.assert_called_once()
+    entities = add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert entities[0].unique_id == "satel_zone_status_1"
+
+
+@pytest.mark.asyncio
+async def test_switch_setup_entry(hass):
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    hub = SatelHub("host", 1234)
+    devices = {"zones": [], "outputs": [{"id": "1", "name": "Out"}]}
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub, "devices": devices}}
+
+    add_entities = MagicMock()
+    await switch.async_setup_entry(hass, entry, add_entities)
+
+    add_entities.assert_called_once()
+    entities = add_entities.call_args[0][0]
+    assert len(entities) == 1
+    assert entities[0].unique_id == "satel_output_1"


### PR DESCRIPTION
## Summary
- add test package with pytest-homeassistant-custom-component
- verify SatelHub connection, command handling and discovery
- cover platform setups and config flow

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_688f92d11a048326a916bffd79e49c2e