### PR TITLE
Fix hub retrieval on unload

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -118,7 +118,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hub: SatelHub = hass.data[DOMAIN].pop(entry.entry_id)
+        data = hass.data[DOMAIN].pop(entry.entry_id)
+        hub: SatelHub = data["hub"]
         if hub._writer is not None:  # pragma: no cover - graceful shutdown
             hub._writer.close()
             await hub._writer.wait_closed()


### PR DESCRIPTION
## Summary
- fix retrieval of hub when unloading entries

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_688f96d89cfc832690c6becdcc6c3576