### PR TITLE
Serialize SatelHub command transmissions

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,8 @@
 """Test suite for Satel integration."""
-pytest_plugins = ["pytest_homeassistant_custom_component"]
+
+try:  # pragma: no cover - optional dependency
+    import pytest_homeassistant_custom_component  # noqa: F401
+
+    pytest_plugins = ["pytest_homeassistant_custom_component"]
+except Exception:  # pragma: no cover - plugin not available
+    pytest_plugins: list[str] = []


### PR DESCRIPTION
## Summary
- ensure only one Satel command is in flight by protecting `send_command` with an `asyncio.Lock`
- test `send_command` serialization and load optional plugin only when available

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*
- `pip install homeassistant==2024.6.3` *(fails: No matching distribution found for home-assistant-bluetooth==1.12.0)*
- `pytest tests/test_hub.py`


------
https://chatgpt.com/codex/tasks/task_e_688f96d978388326bb41f8fc0fc12e67