### PR TITLE
refactor: introduce base entity

### DIFF
--- a/custom_components/satel/binary_sensor.py
+++ b/custom_components/satel/binary_sensor.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import SatelHub
 from .const import DOMAIN
+from .entity import SatelEntity
 
 
 async def async_setup_entry(
@@ -24,23 +24,14 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class SatelZoneBinarySensor(BinarySensorEntity):
+class SatelZoneBinarySensor(SatelEntity, BinarySensorEntity):
     """Binary sensor for a Satel zone."""
 
     def __init__(self, hub: SatelHub, zone_id: str, name: str) -> None:
-        self._hub = hub
+        super().__init__(hub)
         self._zone_id = zone_id
         self._attr_name = name
         self._attr_unique_id = f"satel_zone_{zone_id}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for this entity."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.host)},
-            manufacturer="Satel",
-            name="Satel Alarm",
-        )
 
     async def async_update(self) -> None:
         status = await self._hub.send_command(f"ZONE {self._zone_id}")

--- a/custom_components/satel/entity.py
+++ b/custom_components/satel/entity.py
@@ -1,0 +1,25 @@
+"""Base entity for Satel integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN
+from . import SatelHub
+
+
+class SatelEntity(Entity):
+    """Representation of a Satel entity."""
+
+    def __init__(self, hub: SatelHub) -> None:
+        self._hub = hub
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device information for this entity."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._hub.host)},
+            manufacturer="Satel",
+            name="Satel Alarm",
+        )

--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import SatelHub
 from .const import DOMAIN
+from .entity import SatelEntity
 
 
 async def async_setup_entry(
@@ -24,23 +24,14 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class SatelZoneSensor(SensorEntity):
+class SatelZoneSensor(SatelEntity, SensorEntity):
     """Representation of Satel zone status sensor."""
 
     def __init__(self, hub: SatelHub, zone_id: str, name: str) -> None:
-        self._hub = hub
+        super().__init__(hub)
         self._zone_id = zone_id
         self._attr_name = f"{name} status"
         self._attr_unique_id = f"satel_zone_status_{zone_id}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for this entity."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.host)},
-            manufacturer="Satel",
-            name="Satel Alarm",
-        )
 
     async def async_update(self) -> None:
         self._attr_native_value = await self._hub.send_command(

--- a/custom_components/satel/switch.py
+++ b/custom_components/satel/switch.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 
 from . import SatelHub
 from .const import DOMAIN
+from .entity import SatelEntity
 
 
 async def async_setup_entry(
@@ -24,24 +24,15 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class SatelOutputSwitch(SwitchEntity):
+class SatelOutputSwitch(SatelEntity, SwitchEntity):
     """Switch to control Satel output."""
 
     def __init__(self, hub: SatelHub, output_id: str, name: str) -> None:
-        self._hub = hub
+        super().__init__(hub)
         self._output_id = output_id
         self._attr_name = name
         self._attr_is_on = False
         self._attr_unique_id = f"satel_output_{output_id}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for this entity."""
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._hub.host)},
-            manufacturer="Satel",
-            name="Satel Alarm",
-        )
 
     async def async_turn_on(self, **kwargs) -> None:
         await self._hub.send_command(f"OUTPUT {self._output_id} ON")


### PR DESCRIPTION
## Summary
- create common SatelEntity with shared device info
- inherit entity classes from SatelEntity to remove duplication

## Testing
- `pytest -q --asyncio-mode=auto` *(fails: homeassistant.data_entry_flow.UnknownHandler)*

------
https://chatgpt.com/codex/tasks/task_e_688f96da8104832689f753716218fa1a