### PR TITLE
Refactor Satel shutdown handling

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -7,6 +7,9 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from custom_components.satel.const import DOMAIN
 
 
+pytestmark = [pytest.mark.usefixtures("enable_custom_integrations")]
+
+
 @pytest.mark.asyncio
 async def test_config_flow_full(hass):
     devices = {

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -3,7 +3,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from custom_components.satel import SatelHub
+from custom_components.satel import SatelHub, async_unload_entry, PLATFORMS
+from custom_components.satel.const import DOMAIN
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 @pytest.mark.asyncio
@@ -62,3 +64,36 @@ async def test_discover_devices(monkeypatch):
         "zones": [{"id": "1", "name": "Zone1"}, {"id": "2", "name": "Zone2"}],
         "outputs": [{"id": "1", "name": "Out1"}, {"id": "3", "name": "Out3"}],
     }
+
+
+@pytest.mark.asyncio
+async def test_async_close():
+    hub = SatelHub("1.2.3.4", 1234)
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+    hub._writer = writer
+
+    await hub.async_close()
+
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
+    assert hub._writer is None
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry(hass):
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    hub = SatelHub("host", 1234)
+    hub.async_close = AsyncMock()
+    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub, "devices": {}}}
+    unload = AsyncMock(return_value=True)
+    hass.config_entries.async_unload_platforms = unload
+
+    result = await async_unload_entry(hass, entry)
+
+    assert result is True
+    unload.assert_awaited_once_with(entry, PLATFORMS)
+    hub.async_close.assert_awaited_once()
+    assert entry.entry_id not in hass.data[DOMAIN]


### PR DESCRIPTION
## Summary
- add async_close method to SatelHub and refactor unload to use it
- enable custom integrations in config flow test and add tests for new shutdown logic

## Testing
- `pytest --asyncio-mode=auto -q`


------
https://chatgpt.com/codex/tasks/task_e_688f99acb9708326b69b7394ebb9be19