### PR TITLE
Add command lock to SatelHub

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -26,6 +26,7 @@ class SatelHub:
         self._port = port
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
+        self._lock = asyncio.Lock()
 
     @property
     def host(self) -> str:
@@ -44,10 +45,11 @@ class SatelHub:
         if self._writer is None or self._reader is None:
             raise ConnectionError("Not connected to Satel central")
 
-        _LOGGER.debug("Sending command: %s", command)
-        self._writer.write((command + "\n").encode())
-        await self._writer.drain()
-        data = await self._reader.readline()
+        async with self._lock:
+            _LOGGER.debug("Sending command: %s", command)
+            self._writer.write((command + "\n").encode())
+            await self._writer.drain()
+            data = await self._reader.readline()
         return data.decode().strip()
 
     async def get_status(self) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- ensure sequential command execution with an `asyncio.Lock`

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_688f99b1b12c832694e8d37beb4a114c