### PR TITLE
Ensure Satel switch state updates immediately

### DIFF
--- a/custom_components/satel/switch.py
+++ b/custom_components/satel/switch.py
@@ -37,10 +37,12 @@ class SatelOutputSwitch(SatelEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs) -> None:
         await self._hub.send_command(f"OUTPUT {self._output_id} ON")
         self._attr_is_on = True
+        self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         await self._hub.send_command(f"OUTPUT {self._output_id} OFF")
         self._attr_is_on = False
+        self.async_write_ha_state()
 
     async def async_update(self) -> None:
         state = await self._hub.send_command(f"OUTPUT {self._output_id} STATE")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --asyncio-mode=auto

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -8,7 +8,7 @@ from custom_components.satel.const import DOMAIN
 
 
 @pytest.mark.asyncio
-async def test_config_flow_full(hass):
+async def test_config_flow_full(hass, enable_custom_integrations):
     devices = {
         "zones": [{"id": "1", "name": "Zone"}],
         "outputs": [{"id": "2", "name": "Out"}],

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,33 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.satel import SatelHub
+from custom_components.satel.switch import SatelOutputSwitch
+
+
+@pytest.mark.asyncio
+async def test_turn_on_writes_state():
+    hub = SatelHub("host", 1234)
+    hub.send_command = AsyncMock()
+    switch = SatelOutputSwitch(hub, "1", "Out")
+    switch.async_write_ha_state = MagicMock()
+
+    await switch.async_turn_on()
+
+    assert switch.is_on
+    switch.async_write_ha_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_turn_off_writes_state():
+    hub = SatelHub("host", 1234)
+    hub.send_command = AsyncMock()
+    switch = SatelOutputSwitch(hub, "1", "Out")
+    switch._attr_is_on = True
+    switch.async_write_ha_state = MagicMock()
+
+    await switch.async_turn_off()
+
+    assert not switch.is_on
+    switch.async_write_ha_state.assert_called_once()


### PR DESCRIPTION
## Summary
- Write Home Assistant state after turning Satel switch on or off
- Enable custom integrations in config flow test
- Add tests for switch state updates and configure pytest asyncio mode

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f99b578388326a79d9e26075b5031