### PR TITLE
Safely close writer on Satel unload

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -122,8 +122,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
-        hub: SatelHub = hass.data[DOMAIN].pop(entry.entry_id)
-        if hub._writer is not None:  # pragma: no cover - graceful shutdown
-            hub._writer.close()
-            await hub._writer.wait_closed()
+        entry_data = hass.data[DOMAIN].pop(entry.entry_id, {})
+        hub: SatelHub = entry_data["hub"]
+        if writer := hub._writer:  # pragma: no cover - graceful shutdown
+            writer.close()
+            await writer.wait_closed()
     return unload_ok

--- a/orjson.py
+++ b/orjson.py
@@ -2,6 +2,7 @@ import json
 
 OPT_APPEND_NEWLINE = 0
 OPT_NON_STR_KEYS = 0
+OPT_SORT_KEYS = 0
 JSONDecodeError = ValueError
 
 class Fragment(bytes):

--- a/ulid_transform/__init__.py
+++ b/ulid_transform/__init__.py
@@ -29,3 +29,9 @@ def ulid_to_bytes(u):
 
 def bytes_to_ulid(b):
     return "0" * 26
+
+def bytes_to_ulid_or_none(b):
+    return None
+
+def ulid_to_bytes_or_none(u):
+    return None


### PR DESCRIPTION
## Summary
- Safely close Satel writer when unloading config entries
- Add OPT_SORT_KEYS to orjson stub
- Add missing ulid_transform helper functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa87640c08326a65168c61d199d72