### PR TITLE
Add unload entry test

### DIFF
--- a/tests/test_unload_entry.py
+++ b/tests/test_unload_entry.py
@@ -1,0 +1,30 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.satel import SatelHub, async_unload_entry
+from custom_components.satel.const import DOMAIN
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+
+@pytest.mark.asyncio
+async def test_unload_entry_closes_writer_and_removes_entry(hass):
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    writer = MagicMock()
+    writer.close = MagicMock()
+    writer.wait_closed = AsyncMock()
+
+    hub = SatelHub("host", 1234, "code")
+    hub._writer = writer
+
+    hass.data[DOMAIN] = {entry.entry_id: hub}
+
+    hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+    result = await async_unload_entry(hass, entry)
+
+    assert result
+    writer.close.assert_called_once()
+    writer.wait_closed.assert_awaited_once()
+    assert entry.entry_id not in hass.data[DOMAIN]


### PR DESCRIPTION
## Summary
- add unit test to ensure writer is closed and config entry removed when unloading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fa8764b6083268d9640541f0bb1aa