### PR TITLE
Handle connection errors in config flow

### DIFF
--- a/custom_components/satel/config_flow.py
+++ b/custom_components/satel/config_flow.py
@@ -24,9 +24,13 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._port = user_input[CONF_PORT]
             self._code = user_input[CONF_CODE]
             hub = SatelHub(self._host, self._port, self._code)
-            await hub.connect()
-            self._devices = await hub.discover_devices()
-            return await self.async_step_select()
+            try:
+                await hub.connect()
+                self._devices = await hub.discover_devices()
+            except ConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return await self.async_step_select()
 
         data_schema = vol.Schema(
             {

--- a/orjson.py
+++ b/orjson.py
@@ -2,6 +2,7 @@ import json
 
 OPT_APPEND_NEWLINE = 0
 OPT_NON_STR_KEYS = 0
+OPT_SORT_KEYS = 0
 JSONDecodeError = ValueError
 
 class Fragment(bytes):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -46,3 +46,26 @@ async def test_config_flow_full(hass, enable_custom_integrations):
 
         hub.connect.assert_awaited_once()
         hub.discover_devices.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_config_flow_cannot_connect(hass, enable_custom_integrations):
+    with patch("custom_components.satel.config_flow.SatelHub") as hub_cls:
+        hub = hub_cls.return_value
+        hub.connect = AsyncMock(side_effect=ConnectionError)
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "1.2.3.4", CONF_PORT: 1234, CONF_CODE: "abcd"}
+        )
+        assert result["type"] == data_entry_flow.FlowResultType.FORM
+        assert result["step_id"] == "user"
+        assert result["errors"] == {"base": "cannot_connect"}
+
+        hub.connect.assert_awaited_once()
+        hub.discover_devices.assert_not_called()

--- a/ulid_transform/__init__.py
+++ b/ulid_transform/__init__.py
@@ -29,3 +29,9 @@ def ulid_to_bytes(u):
 
 def bytes_to_ulid(b):
     return "0" * 26
+
+def bytes_to_ulid_or_none(b):
+    return bytes_to_ulid(b) if b else None
+
+def ulid_to_bytes_or_none(u):
+    return ulid_to_bytes(u) if u else None


### PR DESCRIPTION
## Summary
- handle connection errors during Satel config flow
- add regression test for connection failures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa87e11748326b98532f54d2ff982