### PR TITLE
Handle Satel entity connection errors gracefully

### DIFF
--- a/custom_components/satel/binary_sensor.py
+++ b/custom_components/satel/binary_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -9,6 +11,8 @@ from homeassistant.core import HomeAssistant
 from . import SatelHub
 from .const import DOMAIN
 from .entity import SatelEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -34,5 +38,10 @@ class SatelZoneBinarySensor(SatelEntity, BinarySensorEntity):
         self._attr_unique_id = f"satel_zone_{zone_id}"
 
     async def async_update(self) -> None:
-        status = await self._hub.send_command(f"ZONE {self._zone_id}")
+        try:
+            status = await self._hub.send_command(f"ZONE {self._zone_id}")
+        except ConnectionError as err:
+            _LOGGER.warning("Failed to update zone %s: %s", self._zone_id, err)
+            self._attr_is_on = None
+            return
         self._attr_is_on = status.upper() == "ON"

--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -9,6 +11,8 @@ from homeassistant.core import HomeAssistant
 from . import SatelHub
 from .const import DOMAIN
 from .entity import SatelEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -34,6 +38,10 @@ class SatelZoneSensor(SatelEntity, SensorEntity):
         self._attr_unique_id = f"satel_zone_status_{zone_id}"
 
     async def async_update(self) -> None:
-        self._attr_native_value = await self._hub.send_command(
-            f"ZONE {self._zone_id} STATUS"
-        )
+        try:
+            self._attr_native_value = await self._hub.send_command(
+                f"ZONE {self._zone_id} STATUS"
+            )
+        except ConnectionError as err:
+            _LOGGER.warning("Failed to update zone %s: %s", self._zone_id, err)
+            self._attr_native_value = None

--- a/orjson.py
+++ b/orjson.py
@@ -2,6 +2,7 @@ import json
 
 OPT_APPEND_NEWLINE = 0
 OPT_NON_STR_KEYS = 0
+OPT_SORT_KEYS = 0
 JSONDecodeError = ValueError
 
 class Fragment(bytes):

--- a/tests/test_entity_connection_error.py
+++ b/tests/test_entity_connection_error.py
@@ -1,0 +1,71 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.satel import SatelHub
+from custom_components.satel.binary_sensor import SatelZoneBinarySensor
+from custom_components.satel.sensor import SatelZoneSensor
+from custom_components.satel.switch import SatelOutputSwitch
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_update_handles_connection_error():
+    hub = SatelHub("host", 1234, "code")
+    hub.send_command = AsyncMock(side_effect=ConnectionError)
+    entity = SatelZoneBinarySensor(hub, "1", "Zone")
+    entity._attr_is_on = True
+
+    await entity.async_update()
+
+    assert entity.is_on is None
+
+
+@pytest.mark.asyncio
+async def test_sensor_update_handles_connection_error():
+    hub = SatelHub("host", 1234, "code")
+    hub.send_command = AsyncMock(side_effect=ConnectionError)
+    entity = SatelZoneSensor(hub, "1", "Zone")
+    entity._attr_native_value = "value"
+
+    await entity.async_update()
+
+    assert entity.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_switch_update_handles_connection_error():
+    hub = SatelHub("host", 1234, "code")
+    hub.send_command = AsyncMock(side_effect=ConnectionError)
+    entity = SatelOutputSwitch(hub, "1", "Out")
+    entity._attr_is_on = True
+
+    await entity.async_update()
+
+    assert entity.is_on is None
+
+
+@pytest.mark.asyncio
+async def test_switch_turn_on_handles_connection_error():
+    hub = SatelHub("host", 1234, "code")
+    hub.send_command = AsyncMock(side_effect=ConnectionError)
+    entity = SatelOutputSwitch(hub, "1", "Out")
+    entity.async_write_ha_state = MagicMock()
+
+    await entity.async_turn_on()
+
+    assert entity.is_on is False
+    entity.async_write_ha_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_switch_turn_off_handles_connection_error():
+    hub = SatelHub("host", 1234, "code")
+    hub.send_command = AsyncMock(side_effect=ConnectionError)
+    entity = SatelOutputSwitch(hub, "1", "Out")
+    entity._attr_is_on = True
+    entity.async_write_ha_state = MagicMock()
+
+    await entity.async_turn_off()
+
+    assert entity.is_on is True
+    entity.async_write_ha_state.assert_not_called()

--- a/ulid_transform/__init__.py
+++ b/ulid_transform/__init__.py
@@ -29,3 +29,9 @@ def ulid_to_bytes(u):
 
 def bytes_to_ulid(b):
     return "0" * 26
+
+def bytes_to_ulid_or_none(b):
+    return "0" * 26 if b else None
+
+def ulid_to_bytes_or_none(u):
+    return b"0" * 16 if u else None


### PR DESCRIPTION
## Summary
- guard all Satel entity commands against `ConnectionError`
- log failed hub communications without crashing Home Assistant
- add unit tests covering connection failure handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fa87e426c8326b72b4fec22a92d18