### PR TITLE
feat: make encoding configurable

### DIFF
--- a/custom_components/satel/config_flow.py
+++ b/custom_components/satel/config_flow.py
@@ -9,7 +9,14 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 
 from . import SatelHub
-from .const import DOMAIN, DEFAULT_PORT, DEFAULT_HOST, CONF_CODE
+from .const import (
+    DOMAIN,
+    DEFAULT_PORT,
+    DEFAULT_HOST,
+    CONF_CODE,
+    CONF_ENCODING,
+    DEFAULT_ENCODING,
+)
 
 
 class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -23,7 +30,8 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._host = user_input[CONF_HOST]
             self._port = user_input[CONF_PORT]
             self._code = user_input[CONF_CODE]
-            hub = SatelHub(self._host, self._port, self._code)
+            self._encoding = user_input.get(CONF_ENCODING, DEFAULT_ENCODING)
+            hub = SatelHub(self._host, self._port, self._code, self._encoding)
             await hub.connect()
             self._devices = await hub.discover_devices()
             return await self.async_step_select()
@@ -33,6 +41,7 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
                 vol.Required(CONF_PORT, default=DEFAULT_PORT): int,
                 vol.Required(CONF_CODE): str,
+                vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): str,
             }
         )
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
@@ -45,6 +54,7 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_HOST: self._host,
                     CONF_PORT: self._port,
                     CONF_CODE: self._code,
+                    CONF_ENCODING: self._encoding,
                     "zones": user_input.get("zones", []),
                     "outputs": user_input.get("outputs", []),
                 },

--- a/custom_components/satel/const.py
+++ b/custom_components/satel/const.py
@@ -2,3 +2,5 @@ DOMAIN = "satel"
 DEFAULT_PORT = 7094
 DEFAULT_HOST = "127.0.0.1"
 CONF_CODE = "code"
+CONF_ENCODING = "encoding"
+DEFAULT_ENCODING = "utf-8"

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -4,7 +4,12 @@ import pytest
 from homeassistant import data_entry_flow
 from homeassistant.const import CONF_HOST, CONF_PORT
 
-from custom_components.satel.const import DOMAIN, CONF_CODE
+from custom_components.satel.const import (
+    DOMAIN,
+    CONF_CODE,
+    CONF_ENCODING,
+    DEFAULT_ENCODING,
+)
 
 
 @pytest.mark.asyncio
@@ -25,7 +30,13 @@ async def test_config_flow_full(hass, enable_custom_integrations):
         assert result["step_id"] == "user"
 
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "1.2.3.4", CONF_PORT: 1234, CONF_CODE: "abcd"}
+            result["flow_id"],
+            {
+                CONF_HOST: "1.2.3.4",
+                CONF_PORT: 1234,
+                CONF_CODE: "abcd",
+                CONF_ENCODING: DEFAULT_ENCODING,
+            },
         )
         assert result["type"] == data_entry_flow.FlowResultType.FORM
         assert result["step_id"] == "select"
@@ -40,6 +51,7 @@ async def test_config_flow_full(hass, enable_custom_integrations):
             CONF_HOST: "1.2.3.4",
             CONF_PORT: 1234,
             CONF_CODE: "abcd",
+            CONF_ENCODING: DEFAULT_ENCODING,
             "zones": ["1"],
             "outputs": ["2"],
         }


### PR DESCRIPTION
## Summary
- allow configurable response encoding and log decoding issues
- expose encoding option in config flow for non-UTF-8 installations
- update tests for encoding option

## Testing
- `pytest tests/test_hub.py::test_send_command -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*
- `pip install homeassistant==0.7 -q` *(fails: building wheel for yarl did not run successfully)*


------
https://chatgpt.com/codex/tasks/task_e_688fa88800088326beafb8a41ced4b23