### PR TITLE
refactor: consolidate connection test constants

### DIFF
--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -6,6 +6,10 @@ import pytest
 
 from custom_components.satel import SatelHub
 
+HOST = "1.2.3.4"
+PORT = 1234
+CODE = "abcd"
+
 
 @pytest.mark.asyncio
 async def test_connect(monkeypatch):
@@ -16,18 +20,18 @@ async def test_connect(monkeypatch):
     send_mock = AsyncMock()
     monkeypatch.setattr(SatelHub, "send_command", send_mock)
 
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     await hub.connect()
 
-    open_mock.assert_awaited_once_with("1.2.3.4", 1234)
-    send_mock.assert_awaited_once_with("LOGIN abcd")
+    open_mock.assert_awaited_once_with(HOST, PORT)
+    send_mock.assert_awaited_once_with(f"LOGIN {CODE}")
     assert hub._reader is reader
     assert hub._writer is writer
 
 
 @pytest.mark.asyncio
 async def test_send_command(monkeypatch):
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     reader = AsyncMock()
     reader.readline = AsyncMock(return_value=b"OK\n")
     writer = MagicMock()
@@ -46,14 +50,14 @@ async def test_send_command(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_send_command_not_connected():
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     with pytest.raises(ConnectionError):
         await hub.send_command("TEST")
 
 
 @pytest.mark.asyncio
 async def test_send_command_reconnect_success(monkeypatch):
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     reader1 = AsyncMock()
     writer1 = MagicMock()
     writer1.drain = AsyncMock()
@@ -83,7 +87,7 @@ async def test_send_command_reconnect_success(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_send_command_reconnect_failure(monkeypatch):
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     reader1 = AsyncMock()
     writer1 = MagicMock()
     writer1.drain = AsyncMock()
@@ -102,7 +106,7 @@ async def test_send_command_reconnect_failure(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_discover_devices(monkeypatch):
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     monkeypatch.setattr(
         hub,
         "send_command",
@@ -119,7 +123,7 @@ async def test_discover_devices(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_discover_devices_invalid_entries(monkeypatch, caplog):
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     monkeypatch.setattr(
         hub,
         "send_command",
@@ -139,7 +143,7 @@ async def test_discover_devices_invalid_entries(monkeypatch, caplog):
 
 @pytest.mark.asyncio
 async def test_discover_devices_reconnect(monkeypatch):
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     connect_mock = AsyncMock()
     monkeypatch.setattr(hub, "connect", connect_mock)
     send_mock = AsyncMock(
@@ -159,7 +163,7 @@ async def test_discover_devices_reconnect(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_discover_devices_reconnect_failure(monkeypatch, caplog):
-    hub = SatelHub("1.2.3.4", 1234, "abcd")
+    hub = SatelHub(HOST, PORT, CODE)
     connect_mock = AsyncMock()
     monkeypatch.setattr(hub, "connect", connect_mock)
     send_mock = AsyncMock(side_effect=[ConnectionError("boom"), ConnectionError("boom")])


### PR DESCRIPTION
## Summary
- consolidate connection parameters across hub tests to ensure consistency

## Testing
- `pytest tests/test_hub.py`

------
https://chatgpt.com/codex/tasks/task_e_688fb2c1c8cc8326a0ca37519185a8b6