### PR TITLE
chore: clean README and hacs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,3 @@
- codex/extend-config_flow.py-for-credential-handling
-# Satel Alarm Integration
-
-This repository contains a custom Home Assistant integration for Satel alarm systems.
-
-## Configuration
-
-The integration can be configured via the Home Assistant UI. The following options are available:
-
-- `host` (required): Address of the Satel central unit.
-- `port` (required): TCP port used to communicate with the central.
-- `user_code` (optional): Code used for authenticating the connection.
-- `encryption_key` (optional): Encryption key for secure communication.
-
-Provide the appropriate credentials when adding the integration to enable authenticated access to the alarm system.
-=======
- codex/add-unit-tests-for-satelhub-integration
-# Satel Alarm Home Assistant Integration
-
-This custom component provides a simple integration with Satel alarm systems.
-
-## Configuration
-
-### UI setup
-
-1. In Home Assistant navigate to **Settings → Devices & Services**.
-2. Click **Add Integration** and search for **Satel**.
-3. Enter the host and port of your Satel interface and finish the flow.
-
-### YAML configuration
-
-The integration can also be configured in `configuration.yaml`:
-
-```yaml
-satel:
-  host: 192.168.1.2
-  port: 7094
-```
-
-After adding the configuration, restart Home Assistant.
-=======
 # Satel Alarm Integration
 
 Integration with Satel alarm systems for Home Assistant.
@@ -51,11 +10,32 @@ Integration with Satel alarm systems for Home Assistant.
 
 ## Configuration
 
-Configuration is handled through the Home Assistant UI:
+### UI setup
 
-1. Navigate to **Settings → Devices & Services**.
+1. In Home Assistant navigate to **Settings → Devices & Services**.
 2. Click **Add Integration** and search for **Satel Alarm**.
-3. Enter your Satel controller details and complete the setup wizard.
+3. Enter the host and port of your Satel interface and finish the flow.
+
+The integration can be configured via the Home Assistant UI with the following options:
+
+- `host` (required): Address of the Satel central unit.
+- `port` (required): TCP port used to communicate with the central.
+- `user_code` (optional): Code used for authenticating the connection.
+- `encryption_key` (optional): Encryption key for secure communication.
+
+Provide the appropriate credentials when adding the integration to enable authenticated access to the alarm system.
+
+### YAML configuration
+
+The integration can also be configured in `configuration.yaml`:
+
+```yaml
+satel:
+  host: 192.168.1.2
+  port: 7094
+```
+
+After adding the configuration, restart Home Assistant.
 
 ## Supported Features
 
@@ -69,5 +49,4 @@ Configuration is handled through the Home Assistant UI:
 - Ensure the Satel controller is reachable on the network.
 - Check the Home Assistant logs for detailed error messages.
 - Remove and re-add the integration if entities are missing.
- main
- main
+

--- a/hacs.json
+++ b/hacs.json
@@ -1,19 +1,9 @@
 {
- codex/edit-hacs.json-for-integration-details
-  "name": "Satel",
+  "name": "Satel Alarm",
   "content_in_root": false,
   "render_readme": true,
   "domains": ["binary_sensor", "sensor", "switch"],
-=======
-codex/edit-hacs.json-for-satel-alarm
-  "name": "Satel Alarm",
-=======
-  "name": "SATEL",
-main
-  "content_in_root": false,
-  "render_readme": true,
-  "domains": ["sensor", "binary_sensor", "switch"],
- main
   "iot_class": "local_polling",
   "version": "0.1.0"
 }
+


### PR DESCRIPTION
## Summary
- simplify README to remove conflict markers and consolidate setup information
- strip merge conflict debris from `hacs.json`

## Testing
- `pytest -q -c /dev/null` *(fails: 7 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_688fcaaf5b8483269d6c9b6462723ec2