### PR TITLE
refactor: clean constants and imports

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -17,31 +17,17 @@ except ModuleNotFoundError:  # pragma: no cover - simple stubs
     CONF_PORT = "port"
     ConfigType = dict[str, Any]
 
- codex/extend-config_flow.py-for-credential-handling
- codex/extend-config_flow.py-for-credential-handling
-=======
- main
 from .const import (
     DOMAIN,
     DEFAULT_HOST,
     DEFAULT_PORT,
- codex/extend-config_flow.py-for-credential-handling
-    CONF_ENCRYPTION_KEY,
-    CONF_USER_CODE,
-)
-=======
-from .const import DOMAIN, DEFAULT_HOST, DEFAULT_PORT, CONF_CODE
- main
-=======
     CONF_CODE,
-codex/add-configurable-timeout-to-send_command
-    DEFAULT_TIMEOUT,
-=======
+    CONF_USER_CODE,
+    CONF_ENCRYPTION_KEY,
     CONF_ENCODING,
     DEFAULT_ENCODING,
- main
+    DEFAULT_TIMEOUT,
 )
- main
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/satel/config_flow.py
+++ b/custom_components/satel/config_flow.py
@@ -8,37 +8,17 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 
- codex/extend-config_flow.py-for-credential-handling
-from .const import (
-    DOMAIN,
-    DEFAULT_PORT,
-    DEFAULT_HOST,
-    CONF_ENCRYPTION_KEY,
-    CONF_USER_CODE,
-)
-=======
 from . import SatelHub
-codex/add-translations-for-custom-components
- codex/add-translations-for-custom-components
-from .const import DEFAULT_HOST, DEFAULT_PORT, DOMAIN
-=======
-from .const import DOMAIN, DEFAULT_PORT, DEFAULT_HOST, CONF_CODE
- main
-=======
- codex/extend-config_flow.py-for-credential-handling
-from .const import DOMAIN, DEFAULT_PORT, DEFAULT_HOST, CONF_CODE
- main
-=======
 from .const import (
     DOMAIN,
-    DEFAULT_PORT,
     DEFAULT_HOST,
+    DEFAULT_PORT,
     CONF_CODE,
+    CONF_USER_CODE,
+    CONF_ENCRYPTION_KEY,
     CONF_ENCODING,
     DEFAULT_ENCODING,
 )
- main
- main
 
 
 class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/custom_components/satel/const.py
+++ b/custom_components/satel/const.py
@@ -1,18 +1,15 @@
+"""Constants for the Satel integration."""
+
 DOMAIN = "satel"
-DEFAULT_PORT = 7094
+
 DEFAULT_HOST = "127.0.0.1"
- codex/extend-config_flow.py-for-credential-handling
+DEFAULT_PORT = 7094
+
+CONF_CODE = "code"
 CONF_USER_CODE = "user_code"
 CONF_ENCRYPTION_KEY = "encryption_key"
-=======
-CONF_CODE = "code"
-codex/extend-config_flow.py-for-credential-handling
- main
-=======
-codex/add-configurable-timeout-to-send_command
-DEFAULT_TIMEOUT = 10
-=======
 CONF_ENCODING = "encoding"
+
 DEFAULT_ENCODING = "utf-8"
-main
- main
+DEFAULT_TIMEOUT = 10
+


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from Satel consts
- consolidate Satel constants in one location and import them where needed

## Testing
- `pytest -c /dev/null` *(fails: IndentationError: unindent does not match any outer indentation level)*

------
https://chatgpt.com/codex/tasks/task_e_688fcaade0e083268c2be1bc358ac1c6