### PR TITLE
Fix Satel manifest

### DIFF
--- a/custom_components/satel/manifest.json
+++ b/custom_components/satel/manifest.json
@@ -3,18 +3,10 @@
   "name": "Satel Alarm",
   "version": "0.1.0",
   "documentation": "https://github.com/blakinio/satel",
-  "requirements": [
-    "pysatel==0.0.1"
-  ],
+  "requirements": [],
   "dependencies": [],
-  "codeowners": [
-    "@blakinio"
-  ],
+  "codeowners": ["@blakinio"],
   "config_flow": true,
   "iot_class": "local_polling",
-  "authentication": [
-    "user_code",
-    "encryption_key"
-  ],
-  "description": "Connects to a Satel alarm panel and automatically discovers zones and outputs during setup. Discovery uses a basic LIST command and may not detect all device types."
+  "authentication": ["user_code", "encryption_key"]
 }


### PR DESCRIPTION
## Summary
- clean up Satel integration manifest to satisfy Home Assistant schema

## Testing
- `pytest` *(fails: ImportError, SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_688fd2fcbf0883268548392a60926015