### PR TITLE
Remove Home Assistant stubs from Satel platforms

### DIFF
--- a/custom_components/satel/binary_sensor.py
+++ b/custom_components/satel/binary_sensor.py
@@ -4,19 +4,9 @@ from __future__ import annotations
 
 import logging
 
-try:
-    from homeassistant.components.binary_sensor import BinarySensorEntity
-    from homeassistant.config_entries import ConfigEntry
-    from homeassistant.core import HomeAssistant
-except ModuleNotFoundError:  # pragma: no cover - simple stubs
-    class BinarySensorEntity:  # type: ignore
-        pass
-
-    class ConfigEntry:  # type: ignore
-        pass
-
-    class HomeAssistant:  # type: ignore
-        pass
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from . import SatelHub
 from .const import DOMAIN

--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -4,19 +4,9 @@ from __future__ import annotations
 
 import logging
 
-try:
-    from homeassistant.components.sensor import SensorEntity
-    from homeassistant.config_entries import ConfigEntry
-    from homeassistant.core import HomeAssistant
-except ModuleNotFoundError:  # pragma: no cover - simple stubs
-    class SensorEntity:  # type: ignore
-        pass
-
-    class ConfigEntry:  # type: ignore
-        pass
-
-    class HomeAssistant:  # type: ignore
-        pass
+from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from . import SatelHub
 from .const import DOMAIN

--- a/custom_components/satel/switch.py
+++ b/custom_components/satel/switch.py
@@ -4,19 +4,9 @@ from __future__ import annotations
 
 import logging
 
-try:
-    from homeassistant.components.switch import SwitchEntity
-    from homeassistant.config_entries import ConfigEntry
-    from homeassistant.core import HomeAssistant
-except ModuleNotFoundError:  # pragma: no cover - simple stubs
-    class SwitchEntity:  # type: ignore
-        pass
-
-    class ConfigEntry:  # type: ignore
-        pass
-
-    class HomeAssistant:  # type: ignore
-        pass
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 from . import SatelHub
 from .const import DOMAIN


### PR DESCRIPTION
## Summary
- Drop ModuleNotFoundError fallbacks in Satel platform modules
- Rely on Home Assistant's runtime classes for sensors, binary sensors and switches

## Testing
- `pytest` *(fails: SyntaxError in tests/test_config_flow.py, tests/test_switch.py)*

------
https://chatgpt.com/codex/tasks/task_e_688fd4016d9883268ca796ca4e96d1ad