### PR TITLE
Handle hub cleanup on config flow errors

### DIFF
--- a/custom_components/satel/config_flow.py
+++ b/custom_components/satel/config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -50,10 +51,12 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await hub.connect()
                 self._devices = await hub.discover_devices()
-            except (ConnectionError, OSError):
+            except (asyncio.TimeoutError, ConnectionError, OSError):
                 errors["base"] = "cannot_connect"
             else:
                 return await self.async_step_select()
+            finally:
+                await hub.async_close()
 
         data_schema = vol.Schema(
             {


### PR DESCRIPTION
## Summary
- ensure Satel hub connections are closed during config flow
- treat timeouts as connection errors

## Testing
- `pytest` *(fails: SyntaxError in tests/test_config_flow.py, tests/test_switch.py)*

------
https://chatgpt.com/codex/tasks/task_e_688fd691b4f08326a754aa88cda3679b