### PR TITLE
Handle invalid login responses on connection

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -99,7 +99,10 @@ class SatelHub:
                 raise ConnectionError("Authentication failed")
 
         if self._code:
-            await self.send_command(f"LOGIN {self._code}")
+            response = await self.send_command(f"LOGIN {self._code}")
+            if response.strip().upper() != "OK":
+                await self._close_connection()
+                raise ConnectionError("Login failed")
 
     async def send_command(
         self,

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,5 +1,6 @@
 from unittest.mock import AsyncMock, MagicMock
 
+import asyncio
 import pytest
 
 from custom_components.satel import SatelHub
@@ -34,6 +35,48 @@ async def test_send_command_reconnect_success(monkeypatch):
     reconnect_mock.assert_awaited_once()
     writer2.write.assert_called_once_with(b"TEST\n")
     assert response == "OK"
+
+
+@pytest.mark.asyncio
+async def test_connect_login_success(monkeypatch):
+    hub = SatelHub("host", 1234, "code")
+
+    open_conn_mock = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+    monkeypatch.setattr(asyncio, "open_connection", open_conn_mock)
+
+    send_command_mock = AsyncMock(return_value="OK")
+    monkeypatch.setattr(hub, "send_command", send_command_mock)
+
+    await hub.connect()
+
+    open_conn_mock.assert_awaited_once()
+    send_command_mock.assert_awaited_once_with("LOGIN code")
+
+
+@pytest.mark.asyncio
+async def test_connect_login_failure(monkeypatch):
+    hub = SatelHub("host", 1234, "code")
+
+    open_conn_mock = AsyncMock(return_value=(AsyncMock(), AsyncMock()))
+    monkeypatch.setattr(asyncio, "open_connection", open_conn_mock)
+
+    send_command_mock = AsyncMock(return_value="ERR")
+    monkeypatch.setattr(hub, "send_command", send_command_mock)
+
+    async def close_conn():
+        hub._reader = None
+        hub._writer = None
+
+    close_mock = AsyncMock(side_effect=close_conn)
+    monkeypatch.setattr(hub, "_close_connection", close_mock)
+
+    with pytest.raises(ConnectionError):
+        await hub.connect()
+
+    send_command_mock.assert_awaited_once_with("LOGIN code")
+    close_mock.assert_awaited_once()
+    assert hub._reader is None
+    assert hub._writer is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- validate the LOGIN command response during Satel connection
- add tests for successful and failed login handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68905a4c2ea4832693c44165543a1508