### PR TITLE
Add extended zone state handling

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -42,7 +42,15 @@ class SatelHub:
         self._satel: AsyncSatel | None = None
         self._monitor_task: asyncio.Task | None = None
         self._coordinator: DataUpdateCoordinator | None = None
-        self._state: dict[str, Any] = {"alarm": {}, "zones": {}, "outputs": {}}
+        self._state: dict[str, Any] = {
+            "alarm": {},
+            "zones": {},
+            "outputs": {},
+            "troubles": {},
+            "tamper": {},
+            "bypass": {},
+            "alarm_memory": {},
+        }
 
     @property
     def host(self) -> str:  # pragma: no cover - trivial
@@ -70,12 +78,24 @@ class SatelHub:
                     "alarm": self._state["alarm"],
                     "zones": self._state["zones"].copy(),
                     "outputs": self._state["outputs"].copy(),
+                    "troubles": self._state["troubles"].copy(),
+                    "tamper": self._state["tamper"].copy(),
+                    "bypass": self._state["bypass"].copy(),
+                    "alarm_memory": self._state["alarm_memory"].copy(),
                 }
                 self._coordinator.async_set_updated_data(data)
 
         def zone_cb(status: dict[str, Any]) -> None:
             for zone, value in status.get("zones", {}).items():
                 self._state["zones"][str(zone)] = "ON" if value else "OFF"
+            for zone, value in status.get("troubles", {}).items():
+                self._state["troubles"][str(zone)] = "ON" if value else "OFF"
+            for zone, value in status.get("tamper", {}).items():
+                self._state["tamper"][str(zone)] = "ON" if value else "OFF"
+            for zone, value in status.get("bypass", {}).items():
+                self._state["bypass"][str(zone)] = "ON" if value else "OFF"
+            for zone, value in status.get("alarm_memory", {}).items():
+                self._state["alarm_memory"][str(zone)] = "ON" if value else "OFF"
             _schedule_update()
 
         def output_cb(status: dict[str, Any]) -> None:
@@ -135,6 +155,10 @@ class SatelHub:
             "alarm": self._state["alarm"].copy(),
             "zones": self._state["zones"].copy(),
             "outputs": self._state["outputs"].copy(),
+            "troubles": self._state["troubles"].copy(),
+            "tamper": self._state["tamper"].copy(),
+            "bypass": self._state["bypass"].copy(),
+            "alarm_memory": self._state["alarm_memory"].copy(),
         }
 
     async def discover_devices(self) -> dict[str, list[dict[str, Any]]]:

--- a/custom_components/satel/binary_sensor.py
+++ b/custom_components/satel/binary_sensor.py
@@ -57,6 +57,16 @@ class SatelZoneBinarySensor(SatelEntity, BinarySensorEntity):
             return None
         return status.upper() == "ON"
 
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        data = self.coordinator.data
+        return {
+            "troubles": data.get("troubles", {}).get(self._zone_id),
+            "tamper": data.get("tamper", {}).get(self._zone_id),
+            "bypass": data.get("bypass", {}).get(self._zone_id),
+            "alarm_memory": data.get("alarm_memory", {}).get(self._zone_id),
+        }
+
 
 class SatelAlarmBinarySensor(SatelEntity, BinarySensorEntity):
     """Binary sensor representing overall alarm state."""

--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -52,7 +52,22 @@ class SatelZoneSensor(SatelEntity, SensorEntity):
 
     @property
     def native_value(self) -> str | None:
-        return self.coordinator.data.get("zones", {}).get(self._zone_id)
+        data = self.coordinator.data
+        for key in ["tamper", "troubles", "bypass", "alarm_memory"]:
+            value = data.get(key, {}).get(self._zone_id)
+            if isinstance(value, str) and value.upper() == "ON":
+                return key.upper()
+        return data.get("zones", {}).get(self._zone_id)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str | None]:
+        data = self.coordinator.data
+        return {
+            "troubles": data.get("troubles", {}).get(self._zone_id),
+            "tamper": data.get("tamper", {}).get(self._zone_id),
+            "bypass": data.get("bypass", {}).get(self._zone_id),
+            "alarm_memory": data.get("alarm_memory", {}).get(self._zone_id),
+        }
 
 
 class SatelStatusSensor(SatelEntity, SensorEntity):

--- a/custom_components/satel/translations/en.json
+++ b/custom_components/satel/translations/en.json
@@ -27,12 +27,26 @@
   "entity": {
     "binary_sensor": {
       "zone": {
-        "name": "Zone"
+        "name": "Zone",
+        "state_attributes": {
+          "tamper": {"name": "Tamper"},
+          "troubles": {"name": "Troubles"},
+          "bypass": {"name": "Bypass"},
+          "alarm_memory": {"name": "Alarm memory"}
+        }
       }
     },
     "sensor": {
       "zone_status": {
-        "name": "Zone status"
+        "name": "Zone status",
+        "state": {
+          "on": "Violated",
+          "off": "Normal",
+          "tamper": "Tamper",
+          "trouble": "Trouble",
+          "bypass": "Bypass",
+          "alarm_memory": "Alarm memory"
+        }
       }
     },
     "switch": {

--- a/custom_components/satel/translations/pl.json
+++ b/custom_components/satel/translations/pl.json
@@ -27,12 +27,26 @@
   "entity": {
     "binary_sensor": {
       "zone": {
-        "name": "Strefa"
+        "name": "Strefa",
+        "state_attributes": {
+          "tamper": {"name": "Sabotaż"},
+          "troubles": {"name": "Awarie"},
+          "bypass": {"name": "By-pass"},
+          "alarm_memory": {"name": "Pamięć alarmu"}
+        }
       }
     },
     "sensor": {
       "zone_status": {
-        "name": "Status strefy"
+        "name": "Status strefy",
+        "state": {
+          "on": "Naruszona",
+          "off": "Normalna",
+          "tamper": "Sabotaż",
+          "trouble": "Awarie",
+          "bypass": "By-pass",
+          "alarm_memory": "Pamięć alarmu"
+        }
       }
     },
     "switch": {

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -42,7 +42,15 @@ async def test_monitoring_updates_state(hass):
         output_cb = satel.monitor_status.call_args.kwargs["output_changed_callback"]
         alarm_cb = satel.monitor_status.call_args.kwargs["alarm_status_callback"]
 
-        zone_cb({"zones": {1: 1}})
+        zone_cb(
+            {
+                "zones": {1: 1},
+                "tamper": {1: 1},
+                "troubles": {1: 0},
+                "bypass": {1: 1},
+                "alarm_memory": {1: 0},
+            }
+        )
         output_cb({"outputs": {2: 1}})
         satel.partition_states = {AlarmState.TRIGGERED: [1]}
         alarm_cb()
@@ -50,6 +58,9 @@ async def test_monitoring_updates_state(hass):
         assert coordinator.data["zones"]["1"] == "ON"
         assert coordinator.data["outputs"]["2"] == "ON"
         assert coordinator.data["alarm"]["1"] == "TRIGGERED"
+        assert coordinator.data["tamper"]["1"] == "ON"
+        assert coordinator.data["bypass"]["1"] == "ON"
+        assert coordinator.data["troubles"]["1"] == "OFF"
 
 
 @pytest.mark.asyncio

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -19,7 +19,15 @@ async def test_binary_sensor_setup_entry(hass, enable_custom_integrations):
     hub = SatelHub("host", 1234, "code")
     devices = {"zones": [{"id": "1", "name": "Zone"}], "outputs": []}
     async def _update():
-        return {}
+        return {
+            "alarm": {},
+            "zones": {},
+            "outputs": {},
+            "troubles": {},
+            "tamper": {},
+            "bypass": {},
+            "alarm_memory": {},
+        }
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -48,7 +56,15 @@ async def test_sensor_setup_entry(hass, enable_custom_integrations):
     hub = SatelHub("host", 1234, "code")
     devices = {"zones": [{"id": "1", "name": "Zone"}], "outputs": []}
     async def _update2():
-        return {}
+        return {
+            "alarm": {},
+            "zones": {},
+            "outputs": {},
+            "troubles": {},
+            "tamper": {},
+            "bypass": {},
+            "alarm_memory": {},
+        }
 
     coordinator = DataUpdateCoordinator(
         hass,
@@ -77,7 +93,15 @@ async def test_switch_setup_entry(hass, enable_custom_integrations):
     hub = SatelHub("host", 1234, "code")
     devices = {"zones": [], "outputs": [{"id": "1", "name": "Out"}]}
     async def _update3():
-        return {"outputs": {"1": "OFF"}, "zones": {}, "alarm": {}}
+        return {
+            "outputs": {"1": "OFF"},
+            "zones": {},
+            "alarm": {},
+            "troubles": {},
+            "tamper": {},
+            "bypass": {},
+            "alarm_memory": {},
+        }
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -23,7 +23,17 @@ async def test_setup_creates_entities(hass, enable_custom_integrations):
         ), \
         patch(
             "custom_components.satel.SatelHub.get_overview",
-            AsyncMock(return_value={"alarm": {"1": "TRIGGERED"}, "zones": {}, "outputs": {}}),
+            AsyncMock(
+                return_value={
+                    "alarm": {"1": "TRIGGERED"},
+                    "zones": {},
+                    "outputs": {},
+                    "troubles": {},
+                    "tamper": {},
+                    "bypass": {},
+                    "alarm_memory": {},
+                }
+            ),
         ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
@@ -58,11 +68,51 @@ async def test_switch_services(hass, enable_custom_integrations):
             "custom_components.satel.SatelHub.get_overview",
             AsyncMock(
                 side_effect=[
-                    {"alarm": {"1": "READY"}, "zones": {}, "outputs": {"1": "OFF"}},
-                    {"alarm": {"1": "READY"}, "zones": {}, "outputs": {"1": "ON"}},
-                    {"alarm": {"1": "READY"}, "zones": {}, "outputs": {"1": "ON"}},
-                    {"alarm": {"1": "READY"}, "zones": {}, "outputs": {"1": "OFF"}},
-                    {"alarm": {"1": "READY"}, "zones": {}, "outputs": {"1": "OFF"}},
+                    {
+                        "alarm": {"1": "READY"},
+                        "zones": {},
+                        "outputs": {"1": "OFF"},
+                        "troubles": {},
+                        "tamper": {},
+                        "bypass": {},
+                        "alarm_memory": {},
+                    },
+                    {
+                        "alarm": {"1": "READY"},
+                        "zones": {},
+                        "outputs": {"1": "ON"},
+                        "troubles": {},
+                        "tamper": {},
+                        "bypass": {},
+                        "alarm_memory": {},
+                    },
+                    {
+                        "alarm": {"1": "READY"},
+                        "zones": {},
+                        "outputs": {"1": "ON"},
+                        "troubles": {},
+                        "tamper": {},
+                        "bypass": {},
+                        "alarm_memory": {},
+                    },
+                    {
+                        "alarm": {"1": "READY"},
+                        "zones": {},
+                        "outputs": {"1": "OFF"},
+                        "troubles": {},
+                        "tamper": {},
+                        "bypass": {},
+                        "alarm_memory": {},
+                    },
+                    {
+                        "alarm": {"1": "READY"},
+                        "zones": {},
+                        "outputs": {"1": "OFF"},
+                        "troubles": {},
+                        "tamper": {},
+                        "bypass": {},
+                        "alarm_memory": {},
+                    },
                 ]
             ),
         ), \


### PR DESCRIPTION
## Summary
- handle additional Satel zone states (tamper, troubles, bypass, alarm memory)
- surface extended zone attributes in entities and expose translated states
- update tests for new overview structure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890658fb0448326b349bc9b8c767f9d