### PR TITLE
Add satel-integra dependency

### DIFF
--- a/custom_components/satel/manifest.json
+++ b/custom_components/satel/manifest.json
@@ -3,7 +3,7 @@
   "name": "Satel Alarm",
   "version": "0.1.0",
   "documentation": "https://github.com/blakinio/satel",
-  "requirements": [],
+  "requirements": ["satel-integra>=0.3.4"],
   "dependencies": [],
   "codeowners": ["@blakinio"],
   "config_flow": true,


### PR DESCRIPTION
## Summary
- specify satel-integra library requirement in manifest

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68906fed34748326a95cae087eaea2f4