### PR TITLE
Add support for extra Satel zone states

### DIFF
--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -56,8 +56,9 @@ class SatelZoneSensor(SatelEntity, SensorEntity):
         for key in ["tamper", "troubles", "bypass", "alarm_memory"]:
             value = data.get(key, {}).get(self._zone_id)
             if isinstance(value, str) and value.upper() == "ON":
-                return key.upper()
-        return data.get("zones", {}).get(self._zone_id)
+                return "trouble" if key == "troubles" else key
+        zone_state = data.get("zones", {}).get(self._zone_id)
+        return zone_state.lower() if isinstance(zone_state, str) else zone_state
 
     @property
     def extra_state_attributes(self) -> dict[str, str | None]:

--- a/custom_components/satel/translations/en.json
+++ b/custom_components/satel/translations/en.json
@@ -30,7 +30,7 @@
         "name": "Zone",
         "state_attributes": {
           "tamper": {"name": "Tamper"},
-          "troubles": {"name": "Troubles"},
+          "troubles": {"name": "Trouble"},
           "bypass": {"name": "Bypass"},
           "alarm_memory": {"name": "Alarm memory"}
         }

--- a/custom_components/satel/translations/pl.json
+++ b/custom_components/satel/translations/pl.json
@@ -30,7 +30,7 @@
         "name": "Strefa",
         "state_attributes": {
           "tamper": {"name": "Sabotaż"},
-          "troubles": {"name": "Awarie"},
+          "troubles": {"name": "Awaria"},
           "bypass": {"name": "By-pass"},
           "alarm_memory": {"name": "Pamięć alarmu"}
         }

--- a/tests/test_zone_sensor_values.py
+++ b/tests/test_zone_sensor_values.py
@@ -1,0 +1,33 @@
+from unittest.mock import MagicMock
+
+from custom_components.satel.sensor import SatelZoneSensor
+
+
+def test_zone_sensor_native_value_precedence():
+    hub = MagicMock()
+    coordinator = MagicMock()
+    coordinator.data = {
+        "zones": {"1": "ON"},
+        "tamper": {"1": "OFF"},
+        "troubles": {"1": "OFF"},
+        "bypass": {"1": "OFF"},
+        "alarm_memory": {"1": "OFF"},
+    }
+    sensor = SatelZoneSensor(hub, coordinator, "1", "Zone")
+
+    assert sensor.native_value == "on"
+
+    coordinator.data["tamper"]["1"] = "ON"
+    assert sensor.native_value == "tamper"
+
+    coordinator.data["tamper"]["1"] = "OFF"
+    coordinator.data["troubles"]["1"] = "ON"
+    assert sensor.native_value == "trouble"
+
+    coordinator.data["troubles"]["1"] = "OFF"
+    coordinator.data["bypass"]["1"] = "ON"
+    assert sensor.native_value == "bypass"
+
+    coordinator.data["bypass"]["1"] = "OFF"
+    coordinator.data["alarm_memory"]["1"] = "ON"
+    assert sensor.native_value == "alarm_memory"


### PR DESCRIPTION
## Summary
- return additional zone states (tamper, trouble, bypass, alarm memory) for Satel zone sensors
- translate new zone attributes for English and Polish
- test zone sensor state precedence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907992a5cc83268386d37c04e1936e