### PR TITLE
Support for multiple partition states in Satel integration

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -211,31 +211,37 @@ class SatelHub:
             raise ConnectionError("Not connected")
         await self._satel.set_output(self._code, int(output_id), state)
 
-    async def arm(self, partition: int | None = None) -> None:
+    def _resolve_parts(self, partition: int | str | None) -> list[int]:
+        """Return a list with partition id or default to partition 1."""
+        if partition is None:
+            return [1]
+        return [int(partition)]
+
+    async def arm(self, partition: int | str | None = None) -> None:
         if not self._satel:
             raise ConnectionError("Not connected")
-        parts = [partition] if partition else [1]
+        parts = self._resolve_parts(partition)
         await self._satel.arm(self._code, parts, mode=0)
 
-    async def arm_home(self, partition: int | None = None) -> None:
+    async def arm_home(self, partition: int | str | None = None) -> None:
         if not self._satel:
             raise ConnectionError("Not connected")
-        parts = [partition] if partition else [1]
+        parts = self._resolve_parts(partition)
         await self._satel.arm(self._code, parts, mode=1)
 
-    async def arm_night(self, partition: int | None = None) -> None:
+    async def arm_night(self, partition: int | str | None = None) -> None:
         if not self._satel:
             raise ConnectionError("Not connected")
-        parts = [partition] if partition else [1]
+        parts = self._resolve_parts(partition)
         await self._satel.arm(self._code, parts, mode=2)
 
-    async def disarm(self, partition: int | None = None) -> None:
+    async def disarm(self, partition: int | str | None = None) -> None:
         if not self._satel:
             raise ConnectionError("Not connected")
-        parts = [partition] if partition else [1]
+        parts = self._resolve_parts(partition)
         await self._satel.disarm(self._code, parts)
 
-    async def disarm_partition(self, partition: int) -> None:
+    async def disarm_partition(self, partition: int | str) -> None:
         await self.disarm(partition)
 
 

--- a/custom_components/satel/alarm_control_panel.py
+++ b/custom_components/satel/alarm_control_panel.py
@@ -21,6 +21,14 @@ from . import SatelHub
 from .const import DOMAIN
 from .entity import SatelEntity
 
+ALARM_STATE_MAP = {
+    "ARMED_AWAY": STATE_ALARM_ARMED_AWAY,
+    "ARMED_HOME": STATE_ALARM_ARMED_HOME,
+    "ARMED_NIGHT": STATE_ALARM_ARMED_NIGHT,
+    "PENDING": STATE_ALARM_PENDING,
+    "TRIGGERED": STATE_ALARM_TRIGGERED,
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
@@ -72,15 +80,5 @@ class SatelAlarmPanel(SatelEntity, AlarmControlPanelEntity):
         alarm = (
             self.coordinator.data.get("alarm", {}).get(str(self._partition), "")
         ).upper()
-        if alarm == "ARMED_AWAY":
-            return STATE_ALARM_ARMED_AWAY
-        if alarm == "ARMED_HOME":
-            return STATE_ALARM_ARMED_HOME
-        if alarm == "ARMED_NIGHT":
-            return STATE_ALARM_ARMED_NIGHT
-        if alarm == "PENDING":
-            return STATE_ALARM_PENDING
-        if alarm == "TRIGGERED":
-            return STATE_ALARM_TRIGGERED
-        return STATE_ALARM_DISARMED
+        return ALARM_STATE_MAP.get(alarm, STATE_ALARM_DISARMED)
 


### PR DESCRIPTION
## Summary
- normalize partition id handling inside `SatelHub` so arm/disarm commands work with string ids
- centralize alarm state mapping in alarm control panel entity

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68907c33a86c83268d35137aea266e0f