### PR TITLE
Remove local switch state for Satel outputs

### DIFF
--- a/custom_components/satel/switch.py
+++ b/custom_components/satel/switch.py
@@ -42,7 +42,6 @@ class SatelOutputSwitch(SatelEntity, SwitchEntity):
         self._output_id = output_id
         self._attr_name = name
         self._attr_unique_id = f"satel_output_{output_id}"
-        self._attr_is_on = False
 
     @property
     def is_on(self) -> bool:
@@ -58,8 +57,6 @@ class SatelOutputSwitch(SatelEntity, SwitchEntity):
         except ConnectionError as err:
             _LOGGER.warning("Failed to turn on output %s: %s", self._output_id, err)
             return
-        self._attr_is_on = True
-        self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:  # noqa: D401
@@ -69,7 +66,5 @@ class SatelOutputSwitch(SatelEntity, SwitchEntity):
         except ConnectionError as err:
             _LOGGER.warning("Failed to turn off output %s: %s", self._output_id, err)
             return
-        self._attr_is_on = False
-        self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -11,7 +11,7 @@ from custom_components.satel.switch import SatelOutputSwitch
 
 
 @pytest.mark.asyncio
-async def test_turn_on_writes_state(hass):
+async def test_turn_on_requests_refresh(hass):
     hub = SatelHub("host", 1234, "code")
     hub.set_output = AsyncMock()
     coordinator = DataUpdateCoordinator(
@@ -31,12 +31,12 @@ async def test_turn_on_writes_state(hass):
     await switch.async_turn_on()
 
     assert switch.is_on
-    switch.async_write_ha_state.assert_called_once()
+    switch.async_write_ha_state.assert_not_called()
     switch.coordinator.async_request_refresh.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_turn_off_writes_state(hass):
+async def test_turn_off_requests_refresh(hass):
     hub = SatelHub("host", 1234, "code")
     hub.set_output = AsyncMock()
     coordinator = DataUpdateCoordinator(
@@ -47,7 +47,6 @@ async def test_turn_off_writes_state(hass):
         config_entry=MockConfigEntry(domain="satel"),
     )
     switch = SatelOutputSwitch(hub, coordinator, "1", "Out")
-    switch._attr_is_on = True
     switch.async_write_ha_state = MagicMock()
     async def refresh_off():
         coordinator.data = {"outputs": {"1": "OFF"}}
@@ -57,5 +56,5 @@ async def test_turn_off_writes_state(hass):
     await switch.async_turn_off()
 
     assert not switch.is_on
-    switch.async_write_ha_state.assert_called_once()
+    switch.async_write_ha_state.assert_not_called()
     switch.coordinator.async_request_refresh.assert_called_once()


### PR DESCRIPTION
## Summary
- rely on coordinator data for Satel output switch state
- adjust switch tests for coordinator-driven state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68908d3464788326a07b35709ac832c9