### PR TITLE
Use get_running_loop for Satel connection

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -93,7 +93,7 @@ class SatelHub:
 
     async def connect(self) -> None:
         """Create connection to the alarm using the official protocol."""
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         self._satel = AsyncSatel(self._host, self._port, loop)
         # Apply network tuning if available on the underlying library
         if hasattr(self._satel, "_keep_alive_timeout"):


### PR DESCRIPTION
## Summary
- replace deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` when establishing a Satel connection
- verify that `AsyncSatel` accepts the provided loop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68908d33d95483269265c5ff382a9dbc