### PR TITLE
Implement Satel device discovery

### DIFF
--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -79,3 +79,23 @@ async def test_partition_commands():
         await hub.disarm_partition(4)
         satel.disarm.assert_awaited_with("code", [4])
 
+
+@pytest.mark.asyncio
+async def test_discover_devices_reads_names():
+    """Ensure the hub fetches zone and output names from the panel."""
+    satel = AsyncMock()
+    satel.get_zone_names = AsyncMock(return_value={1: "Zone 1"})
+    satel.get_output_names = AsyncMock(return_value={2: "Out 2"})
+    satel._monitored_zones = []
+    satel._monitored_outputs = []
+
+    hub = SatelHub("host", 1234, "code")
+    hub._satel = satel  # pretend already connected
+
+    devices = await hub.discover_devices()
+
+    assert devices["zones"] == [{"id": "1", "name": "Zone 1"}]
+    assert devices["outputs"] == [{"id": "2", "name": "Out 2"}]
+    assert satel._monitored_zones == [1]
+    assert satel._monitored_outputs == [2]
+

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -17,7 +17,14 @@ async def test_binary_sensor_setup_entry(hass, enable_custom_integrations):
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     hub = SatelHub("host", 1234, "code")
-    devices = {"zones": [{"id": "1", "name": "Zone"}], "outputs": []}
+    satel = AsyncMock()
+    satel.get_zone_names = AsyncMock(return_value={1: "Zone"})
+    satel.get_output_names = AsyncMock(return_value={})
+    satel._monitored_zones = []
+    satel._monitored_outputs = []
+    hub._satel = satel
+    devices = await hub.discover_devices()
+
     async def _update():
         return {
             "alarm": {},
@@ -54,7 +61,14 @@ async def test_sensor_setup_entry(hass, enable_custom_integrations):
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     hub = SatelHub("host", 1234, "code")
-    devices = {"zones": [{"id": "1", "name": "Zone"}], "outputs": []}
+    satel = AsyncMock()
+    satel.get_zone_names = AsyncMock(return_value={1: "Zone"})
+    satel.get_output_names = AsyncMock(return_value={})
+    satel._monitored_zones = []
+    satel._monitored_outputs = []
+    hub._satel = satel
+    devices = await hub.discover_devices()
+
     async def _update2():
         return {
             "alarm": {},
@@ -91,7 +105,14 @@ async def test_switch_setup_entry(hass, enable_custom_integrations):
     entry = MockConfigEntry(domain=DOMAIN)
     entry.add_to_hass(hass)
     hub = SatelHub("host", 1234, "code")
-    devices = {"zones": [], "outputs": [{"id": "1", "name": "Out"}]}
+    satel = AsyncMock()
+    satel.get_zone_names = AsyncMock(return_value={})
+    satel.get_output_names = AsyncMock(return_value={1: "Out"})
+    satel._monitored_zones = []
+    satel._monitored_outputs = []
+    hub._satel = satel
+    devices = await hub.discover_devices()
+
     async def _update3():
         return {
             "outputs": {"1": "OFF"},


### PR DESCRIPTION
## Summary
- Discover Satel zones and outputs using the `satel-integra` API
- Test hub discovery logic and ensure platform setup uses fetched entities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68908d335cf48326968b94771b4d3c59