### PR TITLE
Add partitions translations

### DIFF
--- a/custom_components/satel/strings.json
+++ b/custom_components/satel/strings.json
@@ -15,7 +15,8 @@
         "description": "Choose zones and outputs to add.",
         "data": {
           "zones": "Zones",
-          "outputs": "Outputs"
+          "outputs": "Outputs",
+          "partitions": "Partitions"
         }
       }
     },

--- a/custom_components/satel/translations/en.json
+++ b/custom_components/satel/translations/en.json
@@ -15,7 +15,8 @@
         "description": "Choose zones and outputs to add.",
         "data": {
           "zones": "Zones",
-          "outputs": "Outputs"
+          "outputs": "Outputs",
+          "partitions": "Partitions"
         }
       }
     },

--- a/custom_components/satel/translations/pl.json
+++ b/custom_components/satel/translations/pl.json
@@ -15,7 +15,8 @@
         "description": "Wybierz strefy i wyjścia do dodania.",
         "data": {
           "zones": "Strefy",
-          "outputs": "Wyjścia"
+          "outputs": "Wyjścia",
+          "partitions": "Strefy"
         }
       }
     },


### PR DESCRIPTION
## Summary
- add "partitions" selection labels in config flow translations

## Testing
- `PYTHONPATH=/tmp/homeassistant python3 -m script.translations develop --integration satel`
- `pytest` *(fails: ModuleNotFoundError: No module named 'satel_integra')*

------
https://chatgpt.com/codex/tasks/task_e_68908d2782908326bcfcc1ec25501fae