### PR TITLE
Add device class to Satel zone binary sensor

### DIFF
--- a/custom_components/satel/binary_sensor.py
+++ b/custom_components/satel/binary_sensor.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
@@ -41,6 +44,7 @@ class SatelZoneBinarySensor(SatelEntity, BinarySensorEntity):
     """Binary sensor for a Satel zone."""
 
     _attr_translation_key = "zone"
+    _attr_device_class = BinarySensorDeviceClass.MOTION
 
     def __init__(
         self, hub: SatelHub, coordinator, zone_id: str, name: str


### PR DESCRIPTION
## Summary
- mark Satel zone binary sensors as motion sensors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689090a4eed883269ac5fc9ac4156f91