### PR TITLE
Add integration type and issue tracker to manifest

### DIFF
--- a/custom_components/satel/manifest.json
+++ b/custom_components/satel/manifest.json
@@ -3,9 +3,11 @@
   "name": "Satel Alarm",
   "version": "0.1.0",
   "documentation": "https://github.com/blakinio/satel",
+  "issue_tracker": "https://github.com/blakinio/satel/issues",
   "requirements": ["satel-integra>=0.3.4"],
   "dependencies": [],
   "codeowners": ["@blakinio"],
   "config_flow": true,
-  "iot_class": "local_push"
+  "iot_class": "local_push",
+  "integration_type": "hub"
 }


### PR DESCRIPTION
## Summary
- declare the integration as a hub-based component
- link project issue tracker in the manifest

## Testing
- `jq . custom_components/satel/manifest.json`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689090a3823083269853e483338d7cf4