### PR TITLE
Expose monitored zone and output setters

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -91,6 +91,38 @@ class SatelHub:
     def host(self) -> str:  # pragma: no cover - trivial
         return self._host
 
+    @property
+    def monitored_zones(self) -> list[int]:
+        """Return list of zone IDs monitored for state changes."""
+        if not self._satel:
+            raise ConnectionError("Not connected")
+        return getattr(self._satel, "_monitored_zones", [])
+
+    def set_monitored_zones(self, zones: list[int]) -> None:
+        """Expose a public API to configure monitored zones."""
+        if not self._satel:
+            raise ConnectionError("Not connected")
+        if hasattr(type(self._satel), "set_monitored_zones"):
+            self._satel.set_monitored_zones(zones)
+        else:
+            self._satel._monitored_zones = zones
+
+    @property
+    def monitored_outputs(self) -> list[int]:
+        """Return list of output IDs monitored for state changes."""
+        if not self._satel:
+            raise ConnectionError("Not connected")
+        return getattr(self._satel, "_monitored_outputs", [])
+
+    def set_monitored_outputs(self, outputs: list[int]) -> None:
+        """Expose a public API to configure monitored outputs."""
+        if not self._satel:
+            raise ConnectionError("Not connected")
+        if hasattr(type(self._satel), "set_monitored_outputs"):
+            self._satel.set_monitored_outputs(outputs)
+        else:
+            self._satel._monitored_outputs = outputs
+
     async def connect(self) -> None:
         """Create connection to the alarm using the official protocol."""
         loop = asyncio.get_running_loop()
@@ -217,8 +249,8 @@ class SatelHub:
         outputs = [{"id": str(oid), "name": name} for oid, name in sorted(outputs_raw.items())]
 
         # Remember which entities should be monitored for state changes
-        self._satel._monitored_zones = list(zones_raw.keys())
-        self._satel._monitored_outputs = list(outputs_raw.keys())
+        self.set_monitored_zones(list(zones_raw.keys()))
+        self.set_monitored_outputs(list(outputs_raw.keys()))
 
         return {
             "zones": zones,

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -86,16 +86,16 @@ async def test_discover_devices_reads_names():
     satel = AsyncMock()
     satel.get_zone_names = AsyncMock(return_value={1: "Zone 1"})
     satel.get_output_names = AsyncMock(return_value={2: "Out 2"})
-    satel._monitored_zones = []
-    satel._monitored_outputs = []
 
     hub = SatelHub("host", 1234, "code")
     hub._satel = satel  # pretend already connected
+    hub.set_monitored_zones([])
+    hub.set_monitored_outputs([])
 
     devices = await hub.discover_devices()
 
     assert devices["zones"] == [{"id": "1", "name": "Zone 1"}]
     assert devices["outputs"] == [{"id": "2", "name": "Out 2"}]
-    assert satel._monitored_zones == [1]
-    assert satel._monitored_outputs == [2]
+    assert hub.monitored_zones == [1]
+    assert hub.monitored_outputs == [2]
 

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -20,9 +20,9 @@ async def test_binary_sensor_setup_entry(hass, enable_custom_integrations):
     satel = AsyncMock()
     satel.get_zone_names = AsyncMock(return_value={1: "Zone"})
     satel.get_output_names = AsyncMock(return_value={})
-    satel._monitored_zones = []
-    satel._monitored_outputs = []
     hub._satel = satel
+    hub.set_monitored_zones([])
+    hub.set_monitored_outputs([])
     devices = await hub.discover_devices()
 
     async def _update():
@@ -64,9 +64,9 @@ async def test_sensor_setup_entry(hass, enable_custom_integrations):
     satel = AsyncMock()
     satel.get_zone_names = AsyncMock(return_value={1: "Zone"})
     satel.get_output_names = AsyncMock(return_value={})
-    satel._monitored_zones = []
-    satel._monitored_outputs = []
     hub._satel = satel
+    hub.set_monitored_zones([])
+    hub.set_monitored_outputs([])
     devices = await hub.discover_devices()
 
     async def _update2():
@@ -108,9 +108,9 @@ async def test_switch_setup_entry(hass, enable_custom_integrations):
     satel = AsyncMock()
     satel.get_zone_names = AsyncMock(return_value={})
     satel.get_output_names = AsyncMock(return_value={1: "Out"})
-    satel._monitored_zones = []
-    satel._monitored_outputs = []
     hub._satel = satel
+    hub.set_monitored_zones([])
+    hub.set_monitored_outputs([])
     devices = await hub.discover_devices()
 
     async def _update3():


### PR DESCRIPTION
## Summary
- add `set_monitored_zones`/`set_monitored_outputs` methods on `SatelHub`
- update discovery to call the new APIs instead of touching private attributes
- adjust tests to use the public API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689095d7604c8326a115dc08240ed3b1