### PR TITLE
Validate Satel device discovery against missing name helpers

### DIFF
--- a/custom_components/satel/__init__.py
+++ b/custom_components/satel/__init__.py
@@ -208,8 +208,18 @@ class SatelHub:
 
         # The ``satel-integra`` library exposes helpers to fetch configuration
         # of the device.  They return mappings indexed by id, e.g.
-        # ``{1: "Zone 1"}``.  We convert them to the structure expected by
-        # Home Assistant and store the ids for monitoring.
+        # ``{1: "Zone 1"}``.  Some older versions of the library didn't expose
+        # the helpers we rely on, so verify they are available before
+        # attempting to use them and provide a helpful error message if not.
+        if not all(
+            hasattr(self._satel, meth)
+            for meth in ("get_zone_names", "get_output_names")
+        ):
+            raise RuntimeError(
+                "The installed satel_integra library is incompatible: missing "
+                "get_zone_names/get_output_names helpers."
+            )
+
         zones_raw: dict[int, str] = await self._satel.get_zone_names()
         outputs_raw: dict[int, str] = await self._satel.get_output_names()
 

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -99,3 +99,13 @@ async def test_discover_devices_reads_names():
     assert satel._monitored_zones == [1]
     assert satel._monitored_outputs == [2]
 
+
+@pytest.mark.asyncio
+async def test_discover_devices_missing_helpers():
+    """Ensure a helpful error is raised when name helpers are absent."""
+    hub = SatelHub("host", 1234, "code")
+    hub._satel = AsyncMock(spec=[])
+
+    with pytest.raises(RuntimeError, match="incompatible"):
+        await hub.discover_devices()
+


### PR DESCRIPTION
## Summary
- check that the Satel integration's library exposes `get_zone_names` and `get_output_names`
- raise a clear error if those helpers are missing
- test device discovery with and without name helpers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689095d691ec83268efa619d848f2e20