### PR TITLE
Clarify UI setup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Integration with Satel alarm systems for Home Assistant.
 
 1. In Home Assistant navigate to **Settings → Devices & Services**.
 2. Click **Add Integration** and search for **Satel Alarm**.
-3. Enter the host and port of your Satel interface and finish the flow.
+3. Enter the host, port and code of your Satel interface and finish the flow.
 
 The integration can be configured via the Home Assistant UI with the following options:
 
 - `host` (required): Address of the Satel central unit.
 - `port` (required): TCP port used to communicate with the central.
-- `user_code` (optional): Code used for authenticating the connection.
-- `encryption_key` (optional): Encryption key for secure communication.
+- `code` (required): Code used for authenticating the connection.
+
+Other parameters have sensible default values.
 
 Provide the appropriate credentials when adding the integration to enable authenticated access to the alarm system.
 


### PR DESCRIPTION
## Summary
- Document only required `host`, `port`, and `code` fields for UI setup
- Note that other parameters rely on sensible defaults

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890998d073483268197b601043c315e