### PR TITLE
Add code field to configuration translations

### DIFF
--- a/custom_components/satel/strings.json
+++ b/custom_components/satel/strings.json
@@ -7,7 +7,8 @@
         "description": "Set up connection to your Satel alarm panel.",
         "data": {
           "host": "Host",
-          "port": "Port"
+          "port": "Port",
+          "code": "Code"
         }
       },
       "select": {

--- a/custom_components/satel/translations/en.json
+++ b/custom_components/satel/translations/en.json
@@ -7,7 +7,8 @@
         "description": "Set up connection to your Satel alarm panel.",
         "data": {
           "host": "Host",
-          "port": "Port"
+          "port": "Port",
+          "code": "Code"
         }
       },
       "select": {

--- a/custom_components/satel/translations/pl.json
+++ b/custom_components/satel/translations/pl.json
@@ -7,7 +7,8 @@
         "description": "Skonfiguruj połączenie z centralą alarmową Satel.",
         "data": {
           "host": "Host",
-          "port": "Port"
+          "port": "Port",
+          "code": "Kod"
         }
       },
       "select": {


### PR DESCRIPTION
## Summary
- include code in Satel config strings
- update English and Polish translations for code field

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890998ba6e48326baadb6e344616a9e