### PR TITLE
Handle incompatible Satel library

### DIFF
--- a/custom_components/satel/config_flow.py
+++ b/custom_components/satel/config_flow.py
@@ -71,6 +71,8 @@ class SatelConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 await hub.connect()
                 self._devices = await hub.discover_devices()
+            except RuntimeError:
+                errors["base"] = "incompatible"
             except (asyncio.TimeoutError, ConnectionError, OSError):
                 errors["base"] = "cannot_connect"
             except Exception as err:  # pylint: disable=broad-except

--- a/custom_components/satel/strings.json
+++ b/custom_components/satel/strings.json
@@ -23,6 +23,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
+      "incompatible": "Incompatible panel or library",
       "unknown": "Unexpected error"
     }
   }

--- a/custom_components/satel/translations/en.json
+++ b/custom_components/satel/translations/en.json
@@ -23,6 +23,7 @@
     },
     "error": {
       "cannot_connect": "Failed to connect",
+      "incompatible": "Incompatible panel or library",
       "unknown": "Unexpected error"
     }
   },

--- a/custom_components/satel/translations/pl.json
+++ b/custom_components/satel/translations/pl.json
@@ -23,6 +23,7 @@
     },
     "error": {
       "cannot_connect": "Nie udało się połączyć",
+      "incompatible": "Niekompatybilny panel lub biblioteka",
       "unknown": "Nieoczekiwany błąd"
     }
   },


### PR DESCRIPTION
## Summary
- handle incompatible Satel library during config flow
- add translations for new `incompatible` error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6890da79a1b8832696fddcdd8558d71b