### PR TITLE
Refactor Satel integration to use runtime data

### DIFF
--- a/custom_components/satel/alarm_control_panel.py
+++ b/custom_components/satel/alarm_control_panel.py
@@ -17,8 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import SatelHub
-from .const import DOMAIN
+from . import SatelHub, SatelRuntimeData
 from .entity import SatelEntity
 
 
@@ -26,9 +25,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up Satel alarm control panel from a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
-    hub: SatelHub = data["hub"]
-    coordinator = data["coordinator"]
+    data: SatelRuntimeData = entry.runtime_data
+    hub: SatelHub = data.hub
+    coordinator = data.coordinator
     partitions = entry.data.get("partitions") or ["1"]
     async_add_entities(
         [SatelAlarmPanel(hub, coordinator, part) for part in partitions]

--- a/custom_components/satel/binary_sensor.py
+++ b/custom_components/satel/binary_sensor.py
@@ -11,8 +11,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import SatelHub
-from .const import DOMAIN
+from . import SatelHub, SatelRuntimeData
 from .entity import SatelEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,10 +21,10 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up Satel binary sensors based on a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
-    hub: SatelHub = data["hub"]
-    devices = data.get("devices", {})
-    coordinator = data["coordinator"]
+    data: SatelRuntimeData = entry.runtime_data
+    hub: SatelHub = data.hub
+    devices = data.devices or {}
+    coordinator = data.coordinator
 
     entities: list[BinarySensorEntity] = []
     zones = devices.get("zones") or []

--- a/custom_components/satel/sensor.py
+++ b/custom_components/satel/sensor.py
@@ -8,8 +8,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import SatelHub
-from .const import DOMAIN
+from . import SatelHub, SatelRuntimeData
 from .entity import SatelEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,10 +18,10 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up Satel sensors based on a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
-    hub: SatelHub = data["hub"]
-    devices = data.get("devices", {})
-    coordinator = data["coordinator"]
+    data: SatelRuntimeData = entry.runtime_data
+    hub: SatelHub = data.hub
+    devices = data.devices or {}
+    coordinator = data.coordinator
 
     entities: list[SensorEntity] = []
     zones = devices.get("zones") or []

--- a/custom_components/satel/switch.py
+++ b/custom_components/satel/switch.py
@@ -8,8 +8,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from . import SatelHub
-from .const import DOMAIN
+from . import SatelHub, SatelRuntimeData
 from .entity import SatelEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,10 +18,10 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up Satel switches based on a config entry."""
-    data = hass.data[DOMAIN][entry.entry_id]
-    hub: SatelHub = data["hub"]
-    devices = data.get("devices", {})
-    coordinator = data["coordinator"]
+    data: SatelRuntimeData = entry.runtime_data
+    hub: SatelHub = data.hub
+    devices = data.devices or {}
+    coordinator = data.coordinator
 
     entities: list[SwitchEntity] = [
         SatelOutputSwitch(hub, coordinator, output["id"], output.get("name", output["id"]))

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -4,11 +4,10 @@ import pytest
 
 import logging
 
-from custom_components.satel import SatelHub
+from custom_components.satel import SatelHub, SatelRuntimeData
 from custom_components.satel.const import DOMAIN
 from custom_components.satel import binary_sensor, sensor, switch
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
@@ -43,9 +42,7 @@ async def test_binary_sensor_setup_entry(hass, enable_custom_integrations):
         update_method=_update,
         config_entry=MockConfigEntry(domain=DOMAIN),
     )
-    hass.data[DOMAIN] = {
-        entry.entry_id: {"hub": hub, "devices": devices, "coordinator": coordinator}
-    }
+    entry.runtime_data = SatelRuntimeData(hub, devices, coordinator)
 
     add_entities = MagicMock()
     await binary_sensor.async_setup_entry(hass, entry, add_entities)
@@ -87,9 +84,7 @@ async def test_sensor_setup_entry(hass, enable_custom_integrations):
         update_method=_update2,
         config_entry=MockConfigEntry(domain=DOMAIN),
     )
-    hass.data[DOMAIN] = {
-        entry.entry_id: {"hub": hub, "devices": devices, "coordinator": coordinator}
-    }
+    entry.runtime_data = SatelRuntimeData(hub, devices, coordinator)
 
     add_entities = MagicMock()
     await sensor.async_setup_entry(hass, entry, add_entities)
@@ -131,9 +126,7 @@ async def test_switch_setup_entry(hass, enable_custom_integrations):
         update_method=_update3,
         config_entry=MockConfigEntry(domain=DOMAIN),
     )
-    hass.data[DOMAIN] = {
-        entry.entry_id: {"hub": hub, "devices": devices, "coordinator": coordinator}
-    }
+    entry.runtime_data = SatelRuntimeData(hub, devices, coordinator)
 
     add_entities = MagicMock()
     await switch.async_setup_entry(hass, entry, add_entities)

--- a/tests/test_unload_entry.py
+++ b/tests/test_unload_entry.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock
 
-from custom_components.satel import SatelHub, async_unload_entry
+from custom_components.satel import SatelHub, SatelRuntimeData, async_unload_entry
 from custom_components.satel.const import DOMAIN
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -14,7 +14,7 @@ async def test_unload_entry_closes_connection_and_removes_entry(hass):
     hub = SatelHub("host", 1234, "code")
     hub.async_close = AsyncMock()
 
-    hass.data[DOMAIN] = {entry.entry_id: {"hub": hub, "devices": {}, "coordinator": None}}
+    entry.runtime_data = SatelRuntimeData(hub, {}, None)
 
     hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
 
@@ -22,4 +22,4 @@ async def test_unload_entry_closes_connection_and_removes_entry(hass):
 
     assert result
     hub.async_close.assert_awaited_once()
-    assert entry.entry_id not in hass.data[DOMAIN]
+    assert entry.runtime_data is None


### PR DESCRIPTION
## Summary
- store hub, devices, and coordinator in new `SatelRuntimeData`
- expose runtime data via `entry.runtime_data` and update platforms
- clear runtime data and close hub on unload

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895a6b422c88326be03dc2aae71804e