### PR TITLE
Use selectors in Satel config flow

### DIFF
--- a/custom_components/satel/strings.json
+++ b/custom_components/satel/strings.json
@@ -13,7 +13,7 @@
       },
       "select": {
         "title": "Select devices",
-        "description": "Choose zones and outputs to add.",
+        "description": "Choose partitions, zones and outputs to add.",
         "data": {
           "zones": "Zones",
           "outputs": "Outputs",

--- a/custom_components/satel/translations/en.json
+++ b/custom_components/satel/translations/en.json
@@ -13,7 +13,7 @@
       },
       "select": {
         "title": "Select devices",
-        "description": "Choose zones and outputs to add.",
+        "description": "Choose partitions, zones and outputs to add.",
         "data": {
           "zones": "Zones",
           "outputs": "Outputs",

--- a/custom_components/satel/translations/pl.json
+++ b/custom_components/satel/translations/pl.json
@@ -13,11 +13,11 @@
       },
       "select": {
         "title": "Wybierz urządzenia",
-        "description": "Wybierz strefy i wyjścia do dodania.",
+        "description": "Wybierz partycje, strefy i wyjścia do dodania.",
         "data": {
           "zones": "Strefy",
           "outputs": "Wyjścia",
-          "partitions": "Strefy"
+          "partitions": "Partycje"
         }
       }
     },


### PR DESCRIPTION
## Summary
- switch config flow forms to Home Assistant selectors
- allow multi-select for partitions, zones and outputs
- update translation strings for new form fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6895ac05195c83268035c4cd08c13d29